### PR TITLE
Fix: Modifiation de la vérification des chemins

### DIFF
--- a/app/cli/parseur_arguments_cli.py
+++ b/app/cli/parseur_arguments_cli.py
@@ -48,7 +48,7 @@ class ParseurArgumentsCLI(ArgumentParser):
             raise ArgumentCLIException(str(ex)) from ex
 
         # Vérification syntaxique des arguments
-        regex_chemin = r"^[a-zA-Z0-9_\\\-.\/]+$"
+        regex_chemin = r"^[a-zA-Z0-9:_\\\-.\/]+$"
         if not match(regex_chemin, arguments_parses.chemin_log):
             raise ArgumentCLIException(
                 "Le chemin du fichier log doit uniquement contenir les caractères autorisés. "


### PR DESCRIPTION
- Ajout du caractère ':' dans les caractères autorisés dans les chemins fournis par la CLI afin d'autoriser les chemins commençant par C: ou D: