### PR TITLE
Chore: Modification du .gitignore pour les tests unitaires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ __pycache__/
 # Fichiers propres à Python
 .vscode/
 .idea/
+
+# Fichiers propres à Pytest
+.pytest_cache/
+
+# Fichiers propres à Coverage
+.coverage/
+htmlcov/


### PR DESCRIPTION
- Ignore les fichiers propres à Pytest
- Ignore les fichiers propres à Coverage