### PR TITLE
Fix: Suppression d'une vérification incorrecte

### DIFF
--- a/app/cli/parseur_arguments_cli.py
+++ b/app/cli/parseur_arguments_cli.py
@@ -44,8 +44,6 @@ class ParseurArgumentsCLI(ArgumentParser):
         # Analyse des arguments
         try:
             arguments_parses = super().parse_args(args, namespace)
-        except Exception as ex: #Erreurs liées au parsing
-            raise ArgumentCLIException(str(ex)) from ex
         except SystemExit as ex: #Arguments inconnus
             raise ArgumentCLIException() from ex
 


### PR DESCRIPTION
- Suppression d'un except Exception dans parse_args de ParseurArgumentsCLI qui était inutile car l'exception ne peut pas être levé puisque la méthode ne lève que des exceptions de type SystemExit