### PR TITLE
Fix: Amélioration du regex pour les entrées des logs Apache

### DIFF
--- a/app/parse/parseur_log_apache.py
+++ b/app/parse/parseur_log_apache.py
@@ -23,7 +23,7 @@ class ParseurLogApache():
         r'(?P<ip>\S+) (?P<rfc>\S+) (?P<utilisateur>\S+)'
         r' (\[(?P<horodatage>.+?)\]|-) "((?P<methode>\S+) (?P<url>\S+) (?P<protocole>\S+)|-)"'
         r' (?P<code_status>\d+) (?P<taille_octets>\d+|-)'
-        r'( "(?P<ancienne_url>.*?)" "(?P<agent_utilisateur>.*?)")?'
+        r'( "(?P<ancienne_url>.*?)")?( "(?P<agent_utilisateur>.*?)")?'
     )
 
     def __init__(self, chemin_log):


### PR DESCRIPTION
- Amélioration du regex en séparent les groupes ancienne_url et agent_utilisateur afin de permettre à une entrée d'avoir une ancienne url mais pas un agent utilisateur (ou inversement), tandis que ce n'était pas possible dans les versios précédentes