### PR TITLE
Chore: Modification .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ __pycache__/
 .pytest_cache/
 
 # Fichiers propres à Coverage
-.coverage/
+.coverage
 htmlcov/


### PR DESCRIPTION
- Modification de l'erreur .coverage/ en .coverage puisque .coverage est un fichier et non un dossier