### PR TITLE
Test: Amélioration de la couverture des tests unitaires

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           pip install pytest-cov
+          pip install pytest-mock
 
       # Étape 4 : Lancer les tests unitaires
       - name: Lancer les tests unitaires

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,10 @@ from parse.parseur_log_apache import ParseurLogApache, FormatLogApacheInvalideEx
 from analyse.analyseur_log_apache import AnalyseurLogApache
 
 
-if __name__ == "__main__":
+def main():
+    """
+    Point d'entrée de l'application.
+    """
     colorama.init()
     print(colorama.Style.DIM + r"""
                                   .-. .-')                 .-')    .-') _     ('-.  _  .-')  ,---.
@@ -41,3 +44,7 @@ if __name__ == "__main__":
         print(f"Erreur dans l'analyse du log Apache !\n{ex}")
     except Exception as ex:
         print(f"Erreur interne !\n{ex}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/parse/parseur_log_apache.py
+++ b/app/parse/parseur_log_apache.py
@@ -114,11 +114,7 @@ class ParseurLogApache():
 
         # Récupération des informations liées à la réponse
         code_statut = self.get_information_entree(resultat_analyse, "code_status")
-        if code_statut:
-            code_statut = int(code_statut)
-
-        if code_statut is None:
-            raise FormatLogApacheInvalideException("Le code de statut HTTP est obligatoire.")
+        code_statut = int(code_statut)
 
         taille_octets = self.get_information_entree(resultat_analyse, "taille_octets")
         if taille_octets:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,11 @@ lignes_invalides = [
 
         '::1 - - [05/Mar/2025:16:59:43] "DELETE / HTTP/2.1" 200 20',
 
-        '192.168.1.1 - [12/Jan/2025:10:15:32 +0000] "GET /index.html HTTP/1.1" test 532'
+        '- - - [12/Jan/2025:10:15:32 +0000] "GET /index.html HTTP/1.1" 500 532',
+
+        '::1 - - - "GET /index.html HTTP/1.1" 500 532',
+
+        '::1 - - [12/Jan/2025:10:15:32 +0000] "GET /index.html HTTP/1.1" - 120'
 ]
 
 # ------------------
@@ -47,6 +51,7 @@ lignes_invalides = [
 def parseur_arguments_cli():
     """
     Fixture pour initialiser le parseur d'arguments CLI.
+
     Returns:
         ParseurArgumentsCLI: Une instance de la classe :class:`ParseurArgumentsCLI`.
     """
@@ -58,8 +63,10 @@ def log_apache(tmp_path):
     Fixture pour créer et récupérer un fichier de log Apache temporaire.
     Elle permet de générer un fichier de log Apache temporaire contenant
     soit des lignes valides, soit des lignes invalides selon le paramètre fourni.
+
     Args:
         tmp_path (Path): Chemin temporaire fourni par pytest.
+
     Returns:
         Callable[[bool], Path]: Une fonction qui crée et retourne le chemin 
         du fichier de log temporaire.
@@ -67,9 +74,11 @@ def log_apache(tmp_path):
     def _creer_log(valide):
         """
         Crée un fichier de log Apache temporaire.
+
         Args:
             valide (bool): Si ``True``, le fichier contient des lignes de log valides.
                 Sinon, il contient des lignes invalides.
+
         Returns:
             Path: Le chemin du fichier de log temporaire créé.
         """
@@ -87,12 +96,14 @@ def log_apache(tmp_path):
 def parseur_log_apache(log_apache, request):
     """
     Fixture pour initialiser un parseur de fichier de log Apache.
+
     Args:
         log_apache: La fixture pour initialiser un fichier temporaire.
         request: Paramètre de la fonction. Si il est égale à ``False``, cette fixture
             retourne un parseur de log Apache qui analyse un fichier avec un format
             invalide. Sinon, retourne un parseur de log Apache qui analyse un fichier
             avec un format valide.
+
     Returns:
         ParseurLogApache: Une instance de la classe :class:`ParseurLogApache`.
     """
@@ -106,10 +117,31 @@ def fichier_log_apache(parseur_log_apache):
     Fixture pour initialiser une représentation d'un fichier de log Apache.
     Cette représentation comprend par défaut les entrées parsées de la liste
     ``lignes_valides``.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurLogApache`.
+
     Returns:
         FichierLogApache: Une instance de la classe :class:`FichierLogApache`.
     """
     return parseur_log_apache.parse_fichier()
+
+@pytest.fixture()
+def entree_log_apache(fichier_log_apache):
+    """
+    Fixture pour initialiser une représentation d'une entrée d'un fichier de log Apache.
+    Cette représentation comprend par défaut les informations de la première ligne de
+    ``lignes_valides``.
+
+    Args:
+        fichier_log_apache (FichierLogApache): Fixture pour l'instance 
+            de la classe :class:`FichierLogApache`.
+
+    Returns:
+        EntreeLogApache: Une instance de la classe :class:`EntreeLogApache`.
+    """
+    return fichier_log_apache.entrees[0]
 
 @pytest.fixture()
 def analyseur_log_apache(fichier_log_apache):
@@ -117,6 +149,11 @@ def analyseur_log_apache(fichier_log_apache):
     Fixture pour initialiser un analyseur statistique de fichier de log Apache.
     Le fichier qu'analyse cet analyseur comprend par défaut les entrées parsées de la liste
     ``lignes_valides``.
+
+    Args:
+        fichier_log_apache (FichierLogApache): Fixture pour l'instance 
+            de la classe :class:`FichierLogApache`.
+
     Returns:
         AnalyseurLogApache: Une instance de la classe :class:`AnalyseurLogApache`.
     """

--- a/tests/test_donnees_log_apache.py
+++ b/tests/test_donnees_log_apache.py
@@ -1,6 +1,5 @@
 """
-Module des tests unitaires pour les classes contenant les données des logs Apache
-(ClientInformations, RequetesInformations et ReponseInformations).
+Module des tests unitaires pour les classes contenant les données des logs Apache.
 """
 
 import pytest
@@ -9,13 +8,30 @@ from donnees.client_informations import ClientInformations
 from donnees.requete_informations import RequeteInformations
 from donnees.reponse_informations import ReponseInformations
 
+
 @pytest.mark.parametrize("adresse_ip, identifiant_rfc, utilisateur, agent_utilisateur", [
     ("192.168.0.1", "rfc", "utilisateur", "Mozilla/5.0")
 ])
-def test_client_informations_valide(adresse_ip, 
+def test_donnees_client_informations_valide(adresse_ip, 
                                     identifiant_rfc, 
                                     utilisateur, 
                                     agent_utilisateur):
+    """
+    Vérifie que les arguments passés dans le constructeur de la classe :class:`ClientInformations`
+    sont bien récupérés.
+
+    Scénarios testés:
+        - Création d'une instance avec des arguments valides.
+
+    Asserts:
+        - La valeur des arguments sont bien conservées au bon endroit avec la bonne valeur.
+
+    Args:
+        adresse_ip (str): Une adresse IP.
+        identifiant_rfc (str): Un identifiant RFC.
+        utilisateur (str): Un nom d'utilisateur.
+        agent_utilisateur (str): Un User-Agent.
+    """
     client = ClientInformations(
         adresse_ip,
         identifiant_rfc,
@@ -33,10 +49,29 @@ def test_client_informations_valide(adresse_ip,
     ("192.168.0.1", "rfc", False, "Mozilla/5.0"),
     ("192.168.0.1", "rfc", "utilisateur", False)
 ])
-def test_client_exception_type_invalide(adresse_ip, 
+def test_donnees_client_exception_type_invalide(adresse_ip, 
                                         identifiant_rfc, 
                                         utilisateur, 
                                         agent_utilisateur):
+    """
+    Vérifie que la classe renvoie une erreur lorsque un argument de type invalide
+    est passé dans le constructeur.
+
+    Scénarios testés:
+        - Type incorrect pour le paramètre ``adresse_ip``.
+        - Type incorrect pour le paramètre ``identifiant_rfc``.
+        - Type incorrect pour le paramètre ``utilisateur``.
+        - Type incorrect pour le paramètre ``agent_utilisateur``.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        adresse_ip (any): Une adresse IP.
+        identifiant_rfc (any): Un identifiant RFC.
+        utilisateur (any): Un nom d'utilisateur.
+        agent_utilisateur (any): Un User-Agent.
+    """
     with pytest.raises(TypeError):
         client = ClientInformations(
             adresse_ip,
@@ -49,11 +84,28 @@ def test_client_exception_type_invalide(adresse_ip,
     (datetime(2012, 12, 12, 10, 10, 10, tzinfo=timezone(timedelta(hours=10))), 
      "POST", "essaie.fr/contact", "HTTP/1.2", "essaie.fr/accueil")
 ])
-def test_requete_informations_valide(horodatage, 
+def test_donnes_requete_informations_valide(horodatage, 
                                     methode_http, 
                                     url, 
                                     protocole_http,
                                     ancienne_url):
+    """
+    Vérifie que les arguments passés dans le constructeur de la classe :class:`RequeteInformations`
+    sont bien récupérés.
+
+    Scénarios testés:
+        - Création d'une instance avec des arguments valides.
+
+    Asserts:
+        - La valeur des arguments sont bien conservées au bon endroit avec la bonne valeur.
+
+    Args:
+        horodatage (datetime): La date de reception de la requête.
+        methode_http (str): La méthode HTTP utilisée.
+        url (str): La ressource demandée.
+        protocole_http (str): Le protocole HTTP utilisé.
+        ancienne_url (str): L'ancienne ressource demandée.
+    """
     requete = RequeteInformations(
         horodatage,
         methode_http,
@@ -78,11 +130,32 @@ def test_requete_informations_valide(horodatage,
     (datetime(2012, 12, 12, 10, 10, 10, tzinfo=timezone(timedelta(hours=10))), 
      "POST", "essaie.fr/contact", "HTTP/1.2", False),
 ])
-def test_requete_exception_type_invalide(horodatage, 
+def test_donnees_requete_exception_type_invalide(horodatage, 
                                         methode_http, 
                                         url, 
                                         protocole_http,
                                         ancienne_url):
+    """
+    Vérifie que la classe renvoie une erreur lorsque un argument de type invalide
+    est passé dans le constructeur.
+
+    Scénarios testés:
+        - Type incorrect pour le paramètre ``horodatage``.
+        - Type incorrect pour le paramètre ``methode_http``.
+        - Type incorrect pour le paramètre ``url``.
+        - Type incorrect pour le paramètre ``protocole_http``.
+        - Type incorrect pour le paramètre ``ancienne_url``.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        horodatage (any): La date de reception de la requête.
+        methode_http (any): La méthode HTTP utilisée.
+        url (any): La ressource demandée.
+        protocole_http (any): Le protocole HTTP utilisé.
+        ancienne_url (any): L'ancienne ressource demandée.
+    """
     with pytest.raises(TypeError):
         requete = RequeteInformations(
             horodatage, 
@@ -95,8 +168,22 @@ def test_requete_exception_type_invalide(horodatage,
 @pytest.mark.parametrize("code_statut_http, taille_octets", [
     (404, 50)
 ])
-def test_reponse_informations_valide(code_statut_http,
+def test_donnes_reponse_informations_valide(code_statut_http,
                                      taille_octets):
+    """
+    Vérifie que les arguments passés dans le constructeur de la classe :class:`ReponseInformations`
+    sont bien récupérés.
+
+    Scénarios testés:
+        - Création d'une instance avec des arguments valides.
+
+    Asserts:
+        - La valeur des arguments sont bien conservées au bon endroit avec la bonne valeur.
+
+    Args:
+        code_statut_http (int): La code de retour.
+        taille_octets (int): La taille de la réponse en octets.
+    """
     reponse = ReponseInformations(
         code_statut_http,
         taille_octets
@@ -110,6 +197,21 @@ def test_reponse_informations_valide(code_statut_http,
 ])
 def test_reponse_exception_type_invalide(code_statut_http,
                                          taille_octets):
+    """
+    Vérifie que la classe renvoie une erreur lorsque un argument de type invalide
+    est passé dans le constructeur.
+
+    Scénarios testés:
+        - Type incorrect pour le paramètre ``code_statut_http``.
+        - Type incorrect pour le paramètre ``taille_octets``.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        code_statut_http (int): La code de retour.
+        taille_octets (int): La taille de la réponse en octets.
+    """
     with pytest.raises(TypeError):
         reponse = ReponseInformations(
             code_statut_http,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,58 @@
+"""
+Module des tests unitaires pour le point d'entrée de l'application.
+"""
+
+import pytest
+import sys
+from main import main
+from cli.parseur_arguments_cli import ArgumentCLIException
+from parse.parseur_log_apache import FormatLogApacheInvalideException
+
+@pytest.mark.parametrize("exception", [
+    (ArgumentCLIException),
+    (FileNotFoundError),
+    (FormatLogApacheInvalideException),
+    (Exception)
+])
+def test_main_gestion_exception(mocker, exception):
+    """
+    Vérifie que les exceptions sont interceptées dans fichier principal.
+
+    Scénarios testés:
+        - Vérification que les exceptions n'arrête pas le programme.
+
+    Args:
+        mocker (any): Une fixture pour simuler des exceptions.
+        exception (any): L'exception à simuler.
+    """
+    mocker.patch("main.ParseurArgumentsCLI", side_effect=exception)
+    main()
+
+
+def test_main_succes(mocker):
+    """
+    Vérifie le fonctionnement du fichier principal sans exception.
+
+    Scénarios testés:
+        - Vérification que le fichier principal s'execute sans exception lors
+            d'un déroulement normal.
+
+    Args:
+        mocker (any): Une fixture pour simuler des retours pour les classes
+            et méthodes dans main.
+    """
+    # Mock des classes pour simuler un fonctionnement correct
+    mock_parseur_cli = mocker.patch("main.ParseurArgumentsCLI")
+    mock_parseur_cli.return_value.parse_args.return_value = mocker.MagicMock(chemin_log="test.log")
+    
+    mock_parseur_log = mocker.patch("main.ParseurLogApache")
+    mock_parseur_log.return_value.parse_fichier.return_value = mocker.MagicMock()
+    
+    mock_analyseur_log = mocker.patch("main.AnalyseurLogApache")
+    mock_analyseur_log.return_value.get_analyse_complete.return_value = {"chemin": "test.log"}
+    
+    # Vérifie qu'aucune exception n'est levée
+    try:
+        main()
+    except Exception:
+        pytest.fail("Aucune exception ne doit être levée ici")

--- a/tests/test_parseur_arguments_cli.py
+++ b/tests/test_parseur_arguments_cli.py
@@ -37,98 +37,137 @@ arguments_invalides = [
 # Tests unitaires
 
 @pytest.mark.parametrize("arguments", arguments_invalides)
-def test_exception_argument_inconnu(parseur_arguments_cli, arguments):
+def test_parseur_cli_exception_argument_inconnu(parseur_arguments_cli, arguments):
     """
     Vérifie qu'une erreur est retournée lorsque un argument est passé en CLI et qu'il
     n'est pas reconnu.
+
+    Scénarios testés:
+        - Demande de parsage d'arguments avec des arguments invalides.
+
+    Asserts:
+        - Une exception :class:`ArgumentCLIException` est levée lorsque un argument est invalide.
+
     Args:
         parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
-            de la classe ParseurArgumentsCLI.
-        chemin_log (str): Un chemin de fichier valide.
-    Returns:
-        None
+            de la classe :class:`ParseurArgumentsCLI`.
+        argument (list): Une liste avec des arguments.
     """
     with pytest.raises(ArgumentCLIException):
         arguments = parseur_arguments_cli.parse_args(args=arguments)
 
 @pytest.mark.parametrize("chemin_log", chemins_valides)
-def test_recuperation_chemin_log_valide(parseur_arguments_cli, chemin_log):
+def test_parseur_cli_recuperation_chemin_log_valide(parseur_arguments_cli, chemin_log):
     """
     Vérifie que le chemin du log Apache fourni depuis la ligne de commande est bien
     récupéré par le parseur.
+
+    Scénarios testés:
+        - Demande de parsage d'un chemin de log.
+
+    Asserts:
+        - La valeur du chemin de log est bien récupérée et conforme à l'entrée.
+
     Args:
         parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
-            de la classe ParseurArgumentsCLI.
+            de la classe :class:`ParseurArgumentsCLI`.
         chemin_log (str): Un chemin de fichier valide.
-    Returns:
-        None
     """
     arguments = parseur_arguments_cli.parse_args(args=[chemin_log])
     assert arguments.chemin_log == chemin_log
 
 @pytest.mark.parametrize("chemin_log", chemins_invalides)
-def test_exception_chemin_log_invalide(parseur_arguments_cli, chemin_log):
+def test_parseur_cli_exception_chemin_log_invalide(parseur_arguments_cli, chemin_log):
     """
     Vérifie qu'une erreur est retournée lorsque le chemin du log Apache fourni contient
     au moins un caractère non autorisé.
+
+    Scénarios testés:
+        - Demande de parsage d'un chemin de log avec un format invalide.
+
+    Asserts:
+        - Une exception :class:`ArgumentCLIException` est levée.
+
     Args:
         parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
-            de la classe ParseurArgumentsCLI.
+            de la classe :class:`ParseurArgumentsCLI`.
         chemin_log (str): Un chemin de fichier invalide.
-    Returns:
-        None
     """
     with pytest.raises(ArgumentCLIException):
         parseur_arguments_cli.parse_args(args=[chemin_log])
 
 @pytest.mark.parametrize("chemin_sortie", sorties_valides)
-def test_recuperation_chemin_sortie_valide(parseur_arguments_cli, chemin_sortie):
+def test_parseur_cli_recuperation_chemin_sortie_valide(parseur_arguments_cli, chemin_sortie):
     """
     Vérifie que le chemin du fichier de sortie JSON fourni depuis la ligne de commande est bien
     récupéré par le parseur.
+
+    Scénarios testés:
+        - Demande de parsage d'un chemin de fichier de sortie.
+
+    Asserts:
+        - La valeur du chemin de sortie est bien récupérée et conforme à l'entrée.
+
     Args:
-        parseur_arguments_cli: Fixture pour l'instance de la classe ParseurArgumentsCLI
-    Returns:
-        None
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurArgumentsCLI`.
+        chemin_sortie (str): Un chemin de fichier de sortie valide.
     """
     arguments = parseur_arguments_cli.parse_args(args=["fichier.txt", "-s", chemin_sortie])
     assert arguments.sortie == chemin_sortie
 
 @pytest.mark.parametrize("chemin_sortie", chemins_invalides)
-def test_exception_chemin_sortie_invalide(parseur_arguments_cli, chemin_sortie):
+def test_parseur_cli_exception_chemin_sortie_invalide(parseur_arguments_cli, chemin_sortie):
     """
     Vérifie qu'une erreur est retournée lorsque le chemin du fichier de sortie fourni contient
     au moins un caractère non autorisé.
+
+    Scénarios testés:
+        - Demande de parsage d'un chemin de fichier de sortie invalide.
+
+    Asserts:
+        - Une exception :class:`ArgumentCLIException` est levée.
+
     Args:
         parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
-            de la classe ParseurArgumentsCLI.
-        chemin_sortie (str): Un chemin de fichier invalide.
-    Returns:
-        None
+            de la classe :class:`ParseurArgumentsCLI`.
+        chemin_sortie (str): Un chemin de fichier de fichier invalide.
     """
     with pytest.raises(ArgumentCLIException):
         parseur_arguments_cli.parse_args(args=["fichier.txt", "-s", chemin_sortie])
 
-def test_recuperation_chemin_sortie_defaut_valide(parseur_arguments_cli):
+def test_parseur_cli_recuperation_chemin_sortie_defaut_valide(parseur_arguments_cli):
     """
     Vérifie que le chemin du fichier de sortie JSON par défaut est bien appliqué lorsque
     aucun chemin de sortie n'est donné.
+
+    Scénarios testés:
+        - Demande de parsage avec aucun fichier de sortie indiqué.
+
+    Asserts:
+        - La bonne valeur par défaut pour le chemin de sortie à été appliquée.
+
     Args:
-        parseur_arguments_cli: Fixture pour l'instance de la classe ParseurArgumentsCLI
-    Returns:
-        None
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurArgumentsCLI`.
     """
     argument = parseur_arguments_cli.parse_args(args=["fichier.txt"])
     assert argument.sortie == "./analyse-log-apache.json"
 
-def test_verification_extention_chemin_sortie(parseur_arguments_cli):
+def test_parseur_cli_verification_extention_chemin_sortie(parseur_arguments_cli):
     """
     Vérifie qu'une erreur est retournée lorsque le fichier de sortie fourni ne possède
     pas l'extension '.json'.
+
+    Scénarios testés:
+        - Demande de parsage d'un fichier de sortie qui n'est pas un fichier .json.
+
+    Asserts:
+        - Une exception :class:`ArgumentCLIException` est levée.
+
     Args:
-        parseur_arguments_cli: Fixture pour l'instance de la classe ParseurArgumentsCLI
-    Returns:
-        None
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurArgumentsCLI`.
     """
     with pytest.raises(ArgumentCLIException):
         parseur_arguments_cli.parse_args(args=["fichier.txt", "-s", "invalide.txt"])

--- a/tests/test_parseur_log_apache.py
+++ b/tests/test_parseur_log_apache.py
@@ -11,52 +11,72 @@ from parse.parseur_log_apache import ParseurLogApache, FormatLogApacheInvalideEx
 
 # Tests unitaires
 
-def test_exception_fichier_invalide():
+def test_parseur_log_exception_fichier_introuvable():
     """
-    Vérifie qu'une exception est bien levée lorsque le fichier n'existe pas.
-    Returns:
-        None
+    Vérifie qu'une exception est bien levée lorsque le chemin du fichier
+    passé dans le constructeur n'est pas trouvé.
+
+    Scénarios testés:
+        - Création d'une instance avec un chemin invalide.
+
+    Asserts:
+        - Une exception :class:`FileNotFoundError` est levée.
     """
     with pytest.raises(FileNotFoundError):
         parseur = ParseurLogApache("fichier/existe/pas.txt")
 
 @pytest.mark.parametrize("parseur_log_apache", [False], indirect=["parseur_log_apache"])
-def test_exception_fichier_invalide(parseur_log_apache):
+def test_parseur_log_exception_fichier_invalide(parseur_log_apache):
     """
     Vérifie qu'une exception est bien levée lorsque le format d'un fichier n'est
     pas valide (une entrée invalide).
+
+    Scénarios testés:
+        - Parsage d'un fichier invalide.
+
+    Asserts:
+        - Une exception :class:`FormatLogApacheInvalideException` est levée.
+
     Args:
         parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
-            de la classe ParseurLogApache.
-    Returns:
-        None
+            de la classe :class:`ParseurLogApache`.
     """
     with pytest.raises(FormatLogApacheInvalideException):
         fichier = parseur_log_apache.parse_fichier()
 
 @pytest.mark.parametrize("ligne_invalide", lignes_invalides)
-def test_exception_entree_invalide(parseur_log_apache, ligne_invalide):
+def test_parseur_log_exception_entree_invalide(parseur_log_apache, ligne_invalide):
     """
-    Vérifie qu'une exception est bien levée lorsque le format d'au moins une
-    entrée est invalide dans un fichier de log Apache.
+    Vérifie qu'une exception est bien levée lorsque le format d'une entrée
+    est invalide.
+    
+    Scénarios testés:
+        - Parsage d'une entrée invalide.
+
+    Asserts:
+        - Une exception :class:`FormatLogApacheInvalideException` est levée.
+
     Args:
         parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
-            de la classe ParseurLogApache.
-        ligne_log (str): L'entrée à analyser.
-    Returns:
-        None
+            de la classe :class:`ParseurLogApache`.
+        ligne_invalide (str): L'entrée à analyser.
     """
     with pytest.raises(FormatLogApacheInvalideException):
         parseur_log_apache.parse_entree(ligne_invalide)
 
-def test_nombre_entrees_valide(parseur_log_apache):
+def test_parseur_log_nombre_entrees_valide(parseur_log_apache):
     """
     Vérifie que le nombre d'entrées trouvé correspond au nombre de ligne dans le log.
+
+    Scénarios testés:
+        - Parsage d'un fichier et récupération du nombre d'entrées dans ce dernier.
+
+    Asserts:
+        - Le nombre d'entrées récupéré est égale au nombre attendu.
+
     Args:
         parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
-            de la classe ParseurLogApache.
-    Returns:
-        None
+            de la classe :class:`ParseurLogApache`.
     """
     fichier_log = parseur_log_apache.parse_fichier()
     assert len(fichier_log.entrees) == len(lignes_valides)
@@ -67,17 +87,26 @@ def test_nombre_entrees_valide(parseur_log_apache):
     ("horodatage", "12/Jan/2025:10:15:32 +0000"),
     ("Existe pas !", None)
 ])
-def test_regex_recuperation_information_entree(parseur_log_apache, nom_information, retour_attendu):
+def test_parseur_log_regex_recuperation_information_entree(parseur_log_apache, 
+                                                           nom_information, 
+                                                           retour_attendu):
     """
     Vérifie que la récupération des informations à partir d'un résultat de regex fonctionne
-    correctement et que toutes valeurs introuvables ou égales à - renvoient None. 
+    correctement et que toutes valeurs introuvables ou égales à - renvoient None.
+
+    Scénarios testés:
+        - Récupération d'une information avec une valeur.
+        - Récupération d'une information sans valeur (égale à -).
+        - Récupération d'une information inexistante.
+
+    Asserts:
+        - La valeur retournée est égale à celle attendue. 
+    
     Args:
         parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
-            de la classe ParseurLogApache.
+            de la classe :class:`ParseurLogApache`.
         nom_information (str): Nom de l'information à récupérer.
         retour_attendu (Union[None, str]): La valeur attendue de l'information.
-    Returns:
-        None
     """
     ligne = '192.168.1.1 - - [12/Jan/2025:10:15:32 +0000] "GET /index.html HTTP/1.1" 200 532'
     analyse = match(parseur_log_apache.PATTERN_ENTREE_LOG_APACHE, ligne)
@@ -88,11 +117,16 @@ def test_parsage_entree_valide(parseur_log_apache):
     """
     Vérifie qu'une entrée est correctement analysée et que les informations partent
     au bon endroit avec le bon typage.
+
+    Scénarios testés:
+        - Parsage d'une entrée valide et récupération des valeurs trouvées.
+
+    Asserts:
+        - Les valeurs sont égales à celles attendues. 
+
     Args:
         parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
-            de la classe ParseurLogApache.
-    Returns:
-        None
+            de la classe :class:`ParseurLogApache`.
     """
     ligne = '192.168.1.1 - - [12/Jan/2025:10:15:32 +0000] "GET /index.html HTTP/1.1" ' \
     '200 532 "/home" "Chrome/133.0.0.0"'


### PR DESCRIPTION
- Ajout de tests unitaires afin d'augmenter la couverture des tests
  unitaires sur le code
- Amélioration de la docstring des fonctions de test unitaire
- Ajout de la nouvelle dépendance 'pytest-mock' qui est nécessaire pour
  les tests unitaires du module main.py
- Ajout d'une fonction main dans main.py pour faciliter les tests
  unitaires
- Suppression d'une vérification de type dans parseur_log_apache.py qui
  ne pouvait jamais être atteinte grâce au regex