### PR TITLE
Refractor: Mise en conformité avec PEP8

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,4 +1,4 @@
-name: Construction et déploiement de la configuration
+name: Documentation - LogBuster
 
 on:
   push:

--- a/.github/workflows/qualite.yaml
+++ b/.github/workflows/qualite.yaml
@@ -26,7 +26,9 @@ jobs:
       - name: Analyse avec Pylint (note >= 9.0 requise)
         run: |
           SCORE=$(pylint app | grep "Your code has been rated at" | awk '{print $7}' | cut -d"/" -f1)
-          SCORE_NUM=$(echo "$SCORE >= 9.0" | bc)
-          if [ "$SCORE_NUM" -ne 1 ]; then
+          echo "Le score du code dans le dossier app est de $SCORE"
+          SCORE_VALIDE=$(echo "$SCORE >= 9.0" | bc)
+          if [ "$SCORE_VALIDE" -ne 1 ]; then
+            echo "Erreur: La note du code est inférieur à 9."
             exit 1
           fi

--- a/.github/workflows/qualite.yaml
+++ b/.github/workflows/qualite.yaml
@@ -26,11 +26,17 @@ jobs:
 
       - name: Analyse avec Pylint (note >= 9.0 requise)
         run: |
-          pylint app
-          SCORE=$(pylint app | grep "Your code has been rated at" | awk '{print $7}' | cut -d"/" -f1)
+          pylint app > tests-resultats-qualite.txt || true
+          SCORE=$(grep "Your code has been rated at" tests-resultats-qualite.txt | awk '{print $7}' | cut -d"/" -f1)
           echo "Le score du code dans le dossier app est de $SCORE"
           SCORE_VALIDE=$(echo "$SCORE >= 9.0" | bc)
           if [ "$SCORE_VALIDE" -ne 1 ]; then
             echo "Erreur: La note du code est inférieur à 9."
             exit 1
           fi
+      
+      - name: Upload du rapport Pylint
+        uses: actions/upload-artifact@v4
+        with:
+          name: rapport-pylint
+          path: tests-resultats-qualite.txt

--- a/.github/workflows/qualite.yaml
+++ b/.github/workflows/qualite.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Analyse avec Pylint (note >= 9.0 requise)
         run: |
+          pylint app
           SCORE=$(pylint app | grep "Your code has been rated at" | awk '{print $7}' | cut -d"/" -f1)
           echo "Le score du code dans le dossier app est de $SCORE"
           SCORE_VALIDE=$(echo "$SCORE >= 9.0" | bc)

--- a/.github/workflows/qualite.yaml
+++ b/.github/workflows/qualite.yaml
@@ -1,0 +1,32 @@
+name: Qualité code - LogBuster
+
+on:
+  push:
+    branches:
+      - refractor/lisibilite-code
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout du code
+        uses: actions/checkout@v4
+
+      - name: Configuration de Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Installation des dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint
+
+      - name: Analyse avec Pylint (note >= 9.0 requise)
+        run: |
+          SCORE=$(pylint app | grep "Your code has been rated at" | awk '{print $7}' | cut -d"/" -f1)
+          SCORE_NUM=$(echo "$SCORE >= 9.0" | bc)
+          if [ "$SCORE_NUM" -ne 1 ]; then
+            exit 1
+          fi

--- a/.github/workflows/qualite.yaml
+++ b/.github/workflows/qualite.yaml
@@ -22,6 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pylint
+          pip install colorama
 
       - name: Analyse avec Pylint (note >= 9.0 requise)
         run: |

--- a/.github/workflows/qualite.yaml
+++ b/.github/workflows/qualite.yaml
@@ -3,7 +3,7 @@ name: Qualité code - LogBuster
 on:
   push:
     branches:
-      - refractor/lisibilite-code
+      - develop
 
 jobs:
   lint:
@@ -38,5 +38,5 @@ jobs:
       - name: Upload du rapport Pylint
         uses: actions/upload-artifact@v4
         with:
-          name: rapport-pylint
+          name: rapport-qualite-code
           path: tests-resultats-qualite.txt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,5 +48,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: tests-resultats-python-${{ matrix.python-version }} # Nom de l'artefact
+          name: rapport-tests-unitaires-python-${{ matrix.python-version }} # Nom de l'artefact
           path: tests/resultats_pytest # Eléments à sauvegarder

--- a/app/analyse/analyseur_log_apache.py
+++ b/app/analyse/analyseur_log_apache.py
@@ -27,7 +27,8 @@ class AnalyseurLogApache:
                 les statistiques des classements (tops). Par défaut, sa valeur est égale à ``3``.
 
         Raises:
-            TypeError: Si l'argument ``fichier_log_apache`` n'est pas une instance de :class:`FichierLogApache`
+            TypeError: Si l'argument ``fichier_log_apache`` n'est pas une instance 
+                de :class:`FichierLogApache`
                 ou si l'argument ``nombre_par_top`` n'est pas un entier.
             ValueError: Si l'argument ``nombre_par_top`` est inférieur à ``0``.
         """
@@ -41,8 +42,8 @@ class AnalyseurLogApache:
         self.nombre_par_top = nombre_par_top
 
     def _get_repartition_elements(self,
-                          liste_elements: list, 
-                          nom_elements: str, 
+                          liste_elements: list,
+                          nom_elements: str,
                           mode_top_classement: bool = False) -> list:
         """
         Retourne le top 'n' des éléments qui apparaissent le plus dans la liste.
@@ -69,16 +70,18 @@ class AnalyseurLogApache:
         if not isinstance(nom_elements, str):
             raise TypeError("Le nom des éléments doit être une chaîne de caractères")
         if not isinstance(mode_top_classement, bool):
-            raise TypeError("L'indication de l'activation du mode 'top_classement' doi être un booléen.")
-        
+            raise TypeError("L'indication de l'activation du mode 'top_classement' "
+                "doit être un booléen.")
+
         total_elements = len(liste_elements)
         compteur_elements = Counter(liste_elements)
-        top_elements = compteur_elements.most_common(self.nombre_par_top if mode_top_classement else None)
+        top_elements = compteur_elements.most_common(self.nombre_par_top
+                                                     if mode_top_classement else None)
         return [
             {nom_elements: element, "total": total, "taux": total / total_elements * 100}
             for element, total in top_elements
         ]
-    
+
     def get_analyse_complete(self) -> dict:
         """
         Retourne l'analyse complète du fichier de log Apache.
@@ -88,7 +91,8 @@ class AnalyseurLogApache:
             - statistiques:
                         - requetes:
                             - top_urls: voir :meth:`get_top_urls`
-                            - repartition_code_statut_http: voir :meth:`get_total_par_code_statut_http`
+                            - repartition_code_statut_http: 
+                                voir :meth:`get_total_par_code_statut_http`
 
         Returns:
             dict: L'analyse sous forme d'un dictionnaire.
@@ -112,7 +116,7 @@ class AnalyseurLogApache:
             int: Le nombre total d'entrées.
         """
         return len(self.fichier.entrees)
-    
+
     def get_top_urls(self) -> list:
         """
         Retourne le top :attr:`nombre_par_top` des urls les plus demandées.
@@ -130,7 +134,7 @@ class AnalyseurLogApache:
             "url",
             True
         )
-    
+
     def get_total_par_code_statut_http(self) -> list:
         """
         Retourne la répartition des réponses par code de statut htpp retourné.

--- a/app/analyse/analyseur_log_apache.py
+++ b/app/analyse/analyseur_log_apache.py
@@ -32,12 +32,16 @@ class AnalyseurLogApache:
                 ou si l'argument ``nombre_par_top`` n'est pas un entier.
             ValueError: Si l'argument ``nombre_par_top`` est inférieur à ``0``.
         """
+        # Vérification du type des paramètres
         if not isinstance(fichier_log_apache, FichierLogApache):
             raise TypeError("La représentation du fichier doit être de type FichierLogApache.")
         if not isinstance(nombre_par_top, int) or isinstance(nombre_par_top, bool):
             raise TypeError("Le nombre par top doit être un entier.")
+        # Vérification de la valeur du paramètre
         if nombre_par_top < 0:
             raise ValueError("Le nombre par top doit être supérieur ou égale à 0.")
+
+        # Ajout des données
         self.fichier = fichier_log_apache
         self.nombre_par_top = nombre_par_top
 
@@ -65,6 +69,7 @@ class AnalyseurLogApache:
                 :attr:`nombre_par_top` éléments, mais peut en contenir moins s'il y a moins 
                 de :attr:`nombre_par_top` éléments distincts.
         """
+        # Vérification du type des paramètres
         if not isinstance(liste_elements, list):
             raise TypeError("La liste des éléments doit être une instance du type list.")
         if not isinstance(nom_elements, str):
@@ -73,6 +78,7 @@ class AnalyseurLogApache:
             raise TypeError("L'indication de l'activation du mode 'top_classement' "
                 "doit être un booléen.")
 
+        # Analyse de la liste
         total_elements = len(liste_elements)
         compteur_elements = Counter(liste_elements)
         top_elements = compteur_elements.most_common(self.nombre_par_top

--- a/app/cli/afficheur_cli.py
+++ b/app/cli/afficheur_cli.py
@@ -52,7 +52,7 @@ class AfficheurCLI:
             "rayon_laser": elements_animations["rayons_laser"]
         }
 
-    def reecrire_ligne(self, message: str):
+    def reecrire_ligne(self, message: str) -> None:
         """
         Permet d'écrire des caractères par dessus la dernière ligne dans la
         ligne de commande.
@@ -69,11 +69,12 @@ class AfficheurCLI:
         # Validation du paramètre
         if not isinstance(message, str):
             raise TypeError("Le message pour la réécriture doit être une chaîne de caractères.")
+
         # Ecriture du message
         sys.stdout.write("\r" + self.COULEUR_MESSAGE_NORMAL + message)
         sys.stdout.flush()
 
-    def affiche_message(self, message: str):
+    def affiche_message(self, message: str) -> None:
         """
         Permet d'écrire un message commun dans la ligne de commande avec la bonne
         couleur.
@@ -90,10 +91,11 @@ class AfficheurCLI:
         # Validation du paramètre
         if not isinstance(message, str):
             raise TypeError("Le message doit être une chaîne de caractères.")
+
         # Ecriture du message
         print(self.COULEUR_MESSAGE_NORMAL + message, flush=True)
 
-    def affiche_erreur(self, message: str, exception: Exception):
+    def affiche_erreur(self, message: str, exception: Exception) -> None:
         """
         Permet d'écrire un message d'erreur dans la ligne de commande avec la bonne
         couleur.
@@ -114,10 +116,11 @@ class AfficheurCLI:
             raise TypeError("Le message d'erreur doit être une chaîne de caractères.")
         if not isinstance(exception, Exception):
             raise TypeError("L'exception à afficher doit être une instance de Exception.")
+
         # Ecriture du message
         print(self.COULEUR_MESSAGE_ERREUR + f"{message}\n{exception}", flush=True)
 
-    def lance_animation_chargement(self):
+    def lance_animation_chargement(self) -> None:
         """
         Lance une animation de chargement dans la ligne de commande via un thread non bloquant.
         Si l'animation de chargement est déjà en cours, cette méthode ne fait rien.
@@ -136,7 +139,7 @@ class AfficheurCLI:
             # Lancement du thread pour le chargement
             self._thread_chargement.start()
 
-    def _animation_chargement(self):
+    def _animation_chargement(self) -> None:
         """
         Lance l'animation de chargement en boucle jusqu'à la demande d'arrêt via
         l'attribut :attr:`_thread_chargement_demande_arret`.
@@ -191,7 +194,7 @@ class AfficheurCLI:
             # Message d'animation erreur
             self.reecrire_ligne(f"{chasseur_perd}{espace_rayon_laser}\033[0m{fantome_gagne}\n")
 
-    def stop_animation_chargement(self, erreur: bool = False):
+    def stop_animation_chargement(self, erreur: bool = False) -> None:
         """
         Lance une demande d'arrêt au thread qui gère l'animation de chargement
         en cours. Si aucune animation n'est en cours, cette méthode ne fait rien.
@@ -202,6 +205,10 @@ class AfficheurCLI:
         Returns:
             None
         """
+        # Vérification du type du paramètre
+        if not isinstance(erreur, bool):
+            raise TypeError("L'indication d'une erreur doit être un booléan.")
+
         # Si le thread de chargement existe et est lancé
         if self._thread_chargement and self._thread_chargement.is_alive():
             # Lancement de la demade d'arrêt

--- a/app/cli/afficheur_cli.py
+++ b/app/cli/afficheur_cli.py
@@ -7,8 +7,9 @@ from pathlib import Path
 from json import load
 from time import sleep
 from random import choice
-import colorama
 import threading
+import colorama
+
 
 class AfficheurCLI:
     """
@@ -130,10 +131,11 @@ class AfficheurCLI:
             self._thread_chargement_termine.clear()
             self._thread_chargement_erreur.clear()
             # Initialisation du thread pour le chargement
-            self._thread_chargement = threading.Thread(target=self._animation_chargement, daemon=True)
+            self._thread_chargement = threading.Thread(target=self._animation_chargement,
+                                                       daemon=True)
             # Lancement du thread pour le chargement
             self._thread_chargement.start()
-        
+
     def _animation_chargement(self):
         """
         Lance l'animation de chargement en boucle jusqu'à la demande d'arrêt via
@@ -147,7 +149,7 @@ class AfficheurCLI:
         fantome_chargement = self._animations_actuelles["fantome"][0]
         signes_rayon_laser = self._animations_actuelles["rayon_laser"]
         couleurs = ["\033[91m", "\033[93m", "\033[94m", "\033[95m"] # Rouge, Jaune, Bleu, Magenta
-        
+
         # Eléments de l'animation de fin de chargement en cas de succès
         chasseur_gagne = self._animations_actuelles["chasseur"][2]
         fantome_perd = self._animations_actuelles["fantome"][1]
@@ -164,7 +166,7 @@ class AfficheurCLI:
         while not (self._thread_chargement_termine.is_set()
                    or self._thread_chargement_erreur.is_set()):
             # Arrête d'ajouter des caractères lorsque la chaîne est trop longue
-            if (index_boucle < 40):
+            if index_boucle < 40:
                 # Récupération de la prochaine couleur
                 couleur_courante = couleurs[(index_boucle % len(couleurs))]
                 # Récupération du prochain signe du rayon
@@ -172,17 +174,19 @@ class AfficheurCLI:
                 # Ajout du dernier signe avec la nouvelle couleur au rayon
                 rayon_laser += couleur_courante + signe_courant
                 # Réactualisation de l'animation de chargement
-                self.reecrire_ligne(f"{chasseur_chargement}{rayon_laser}\033[0m{fantome_chargement}")
+                self.reecrire_ligne(
+                    f"{chasseur_chargement}{rayon_laser}\033[0m{fantome_chargement}"
+                )
                 index_boucle += 1
             sleep(0.05)
 
         # Suppression de la ligne de chargement
         self.reecrire_ligne("\033[K")
         espace_rayon_laser = " " * index_boucle
-        if (self._thread_chargement_termine.is_set()):
+        if self._thread_chargement_termine.is_set():
             # Message d'animation terminée
             self.reecrire_ligne(f"{chasseur_gagne}{espace_rayon_laser}\033[0m{fantome_perd}\n")
-            self.affiche_message(f"Analyse terminée! We came, we saw, we logged it.")
+            self.affiche_message("Analyse terminée! We came, we saw, we logged it.")
         else:
             # Message d'animation erreur
             self.reecrire_ligne(f"{chasseur_perd}{espace_rayon_laser}\033[0m{fantome_gagne}\n")

--- a/app/cli/parseur_arguments_cli.py
+++ b/app/cli/parseur_arguments_cli.py
@@ -22,7 +22,7 @@ class ParseurArgumentsCLI(ArgumentParser):
         )
         self.__set_arguments()
 
-    def __set_arguments(self):
+    def __set_arguments(self) -> None:
         """
         Définit les arguments attendus par l'application.
 
@@ -45,24 +45,32 @@ class ParseurArgumentsCLI(ArgumentParser):
             "nom 'analyse-log-apache.json' dans le repertoire courant sera crée.",
         )
 
-    def parse_args(self, args: Optional[list] = None, namespace: Optional[Namespace] = None):
+    def parse_args(self,
+                   args: Optional[list] = None,
+                   namespace: Optional[Namespace] = None) -> Namespace:
         """
         Récupère les arguments passés en ligne de commande puis vérifie
         que leur format est conforme à ceux attendus.
 
         Args:
             args (Optional[list]): Liste des arguments passés en paramètre. 
-                Si `None`, les arguments de la ligne de commande sont utilisés.
-            namespace (Optional[argparse.Namespace]): Un espace de noms (namespace) 
-                pour stocker les résultats. Si `None`, un nouvel espace de noms est créé.
+                Si ``None``, les arguments de la ligne de commande sont utilisés.
+            namespace (Optional[Namespace]): Un espace de noms (namespace) 
+                pour stocker les résultats. Si ``None``, un nouvel espace de noms est créé.
 
         Returns:
-            argparse.Namespace: L'objet contenant les arguments analysés et leurs valeurs.
+            Namespace: L'objet contenant les arguments analysés et leurs valeurs.
         
         Raises:
             ArgumentCLIException: Si une erreur se produit lors du parsing des arguments 
                 (par exemple, si un argument inconnu est fourni ou si son format est invalide).
         """
+        # Vérification du type des paramètres
+        if args is not None and not isinstance(args, list):
+            raise TypeError("Les arguments doivent soit être None, soit être dans une liste.")
+        if namespace is not None and not isinstance(args, Namespace):
+            raise TypeError("L'espace de noms doit soit être None, soit être un objet Namespace.")
+
         # Analyse des arguments
         try:
             arguments_parses = super().parse_args(args, namespace)

--- a/app/cli/parseur_arguments_cli.py
+++ b/app/cli/parseur_arguments_cli.py
@@ -2,8 +2,10 @@
 Module pour analyser les arguments passés en ligne de commande.
 """
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from re import match
+from typing import Optional
+
 
 class ParseurArgumentsCLI(ArgumentParser):
     """
@@ -12,6 +14,9 @@ class ParseurArgumentsCLI(ArgumentParser):
     """
 
     def __init__(self):
+        """
+        Initialise uparseur pour analyser les arguments passés en ligne de commande.
+        """
         super().__init__(
             description="LogBuster, l'analyseur de log Apache.", allow_abbrev=False,
         )
@@ -20,6 +25,9 @@ class ParseurArgumentsCLI(ArgumentParser):
     def __set_arguments(self):
         """
         Définit les arguments attendus par l'application.
+
+        Returns:
+            None
         """
         # -- Argument obligatoire --
         self.add_argument(
@@ -37,9 +45,23 @@ class ParseurArgumentsCLI(ArgumentParser):
             "nom 'analyse-log-apache.json' dans le repertoire courant sera crée.",
         )
 
-    def parse_args(self, args=None, namespace=None):
+    def parse_args(self, args: Optional[list] = None, namespace: Optional[Namespace] = None):
         """
-        Analyse, vérifie et retourne les arguments fournis en ligne de commande.
+        Récupère les arguments passés en ligne de commande puis vérifie
+        que leur format est conforme à ceux attendus.
+
+        Args:
+            args (Optional[list]): Liste des arguments passés en paramètre. 
+                Si `None`, les arguments de la ligne de commande sont utilisés.
+            namespace (Optional[argparse.Namespace]): Un espace de noms (namespace) 
+                pour stocker les résultats. Si `None`, un nouvel espace de noms est créé.
+
+        Returns:
+            argparse.Namespace: L'objet contenant les arguments analysés et leurs valeurs.
+        
+        Raises:
+            ArgumentCLIException: Si une erreur se produit lors du parsing des arguments 
+                (par exemple, si un argument inconnu est fourni ou si son format est invalide).
         """
         # Analyse des arguments
         try:
@@ -49,29 +71,33 @@ class ParseurArgumentsCLI(ArgumentParser):
 
         # Vérification syntaxique des arguments
         regex_chemin = r"^[a-zA-Z0-9:_\\\-.\/]+$"
+
         if not match(regex_chemin, arguments_parses.chemin_log):
             raise ArgumentCLIException(
                 "Le chemin du fichier log doit uniquement contenir les caractères autorisés. "
                 "Les caractères autorisés sont les minuscules, majuscules, chiffres ou les "
                 "caractères spéciaux suivants: _, \\, -, /."
             )
+
         if not match(regex_chemin, arguments_parses.sortie):
             raise ArgumentCLIException(
                 "Le chemin du fichier de sortie doit uniquement contenir les caractères "
                 "autorisés. Les caractères autorisés sont les minuscules, majuscules, "
                 "chiffres ou les caractères spéciaux suivants: _, \\, -, /."
             )
+
         if not arguments_parses.sortie.endswith(".json"):
             raise ArgumentCLIException(
                 "Le fichier de sortie doit obligatoirement être un fichier au format json."
             )
-        
+
         return arguments_parses
 
 
 class ArgumentCLIException(Exception):
     """
-    Représente une erreur liée l'analyse d'un argument en ligne de commande.
+    Représente une erreur lorsque un argument passé en ligne de commande
+    est inconnu ou que son format est invalide.
     """
 
     def __init__(self, *args):

--- a/app/donnees/client_informations.py
+++ b/app/donnees/client_informations.py
@@ -22,9 +22,6 @@ class ClientInformations:
             Peut être None si non fournie.
         agent_utilisateur (Optional[str]): L'agent utilisateur (User-Agent). 
             Peut être None si non fournie.
-
-    Raises:
-        TypeError: Si les attributs ne sont pas de type `str` ou `None`.
     """
     adresse_ip: str
     identifiant_rfc: Optional[str]
@@ -32,6 +29,12 @@ class ClientInformations:
     agent_utilisateur: Optional[str]
 
     def __post_init__(self):
+        """
+        Vérifie le bon type des données de cette classe lors de l'initialisation de l'instance.
+
+        Raises:
+            TypeError: Une donnée n'est pas du bon type.
+        """
         # Validation de l'adresse IP
         if not isinstance(self.adresse_ip, str):
             raise TypeError("L'adresse IP est obligatoire et doit être une chaîne de caractères.")

--- a/app/donnees/client_informations.py
+++ b/app/donnees/client_informations.py
@@ -14,7 +14,7 @@ class ClientInformations:
     Cette classe regroupe les données extraites d'une entrée de log,
     qui concernent le client ayant effectué la requête au serveur Apache.
 
-    Args:
+    Attributes:
         adresse_ip (str): L'adresse IP du client.
         identifiant_rfc (Optional[str]): L'identifiant RFC du client. 
             Peut être None si non fournie.

--- a/app/donnees/client_informations.py
+++ b/app/donnees/client_informations.py
@@ -36,11 +36,11 @@ class ClientInformations:
         if not isinstance(self.adresse_ip, str):
             raise TypeError("L'adresse IP est obligatoire et doit être une chaîne de caractères.")
         # Validation de l'identifiant RFC
-        if self.identifiant_rfc != None and not isinstance(self.identifiant_rfc, str):
+        if self.identifiant_rfc is not None and not isinstance(self.identifiant_rfc, str):
             raise TypeError("L'identifiant RFC doit être une chaîne de caractères ou None.")
         # Validation du nom d'utilisateur
-        if self.nom_utilisateur != None and not isinstance(self.nom_utilisateur, str):
+        if self.nom_utilisateur is not None and not isinstance(self.nom_utilisateur, str):
             raise TypeError("Le nom d'utilisateur doit être une chaîne de caractères ou None.")
         # Validation de l'agent utilisateur
-        if self.agent_utilisateur != None and not isinstance(self.agent_utilisateur, str):
+        if self.agent_utilisateur is not None and not isinstance(self.agent_utilisateur, str):
             raise TypeError("L'agent utilisateur doit être une chaîne de caractères ou None.")

--- a/app/donnees/reponse_informations.py
+++ b/app/donnees/reponse_informations.py
@@ -19,15 +19,18 @@ class ReponseInformations:
         code_statut_http (int): Le code de statut HTTP.
         taille_octets (Optional[int]): La taille de la réponse en octets.
             Peut être None si non fournie.
-
-    Raises:
-        TypeError: Si les attributs ne sont pas du type int.
     """
 
     code_statut_http: int
     taille_octets: Optional[int]
 
     def __post_init__(self):
+        """
+        Vérifie le bon type des données de cette classe lors de l'initialisation de l'instance.
+
+        Raises:
+            TypeError: Une donnée n'est pas du bon type.
+        """
         # Vérification du code de statut HTTP
         if (not isinstance(self.code_statut_http, int)
         or isinstance(self.code_statut_http, bool)):

--- a/app/donnees/reponse_informations.py
+++ b/app/donnees/reponse_informations.py
@@ -29,11 +29,11 @@ class ReponseInformations:
 
     def __post_init__(self):
         # Vérification du code de statut HTTP
-        if (not isinstance(self.code_statut_http, int) 
+        if (not isinstance(self.code_statut_http, int)
         or isinstance(self.code_statut_http, bool)):
             raise TypeError("Le code de statut HTTP doit être un entier.")
         # Vérification de la taille de la réponse (en octets)
-        if (self.taille_octets != None 
+        if (self.taille_octets is not None
             and not isinstance(self.taille_octets, int)
             or isinstance(self.taille_octets, bool)):
             raise TypeError("La taille en octets doit être un entier ou None.")

--- a/app/donnees/reponse_informations.py
+++ b/app/donnees/reponse_informations.py
@@ -15,7 +15,7 @@ class ReponseInformations:
     qui concernent les informations techniques sur la réponse émise par
     le serveur Apache au client.
 
-    Args:
+    Attributes:
         code_statut_http (int): Le code de statut HTTP.
         taille_octets (Optional[int]): La taille de la réponse en octets.
             Peut être None si non fournie.

--- a/app/donnees/requete_informations.py
+++ b/app/donnees/requete_informations.py
@@ -40,14 +40,14 @@ class RequeteInformations:
         if not isinstance(self.horodatage, datetime):
             raise TypeError("L'horodatage doit être de type datetime.")
         # Vérification de la méthode HTTP
-        if self.methode_http != None and not isinstance(self.methode_http, str):
+        if self.methode_http is not None and not isinstance(self.methode_http, str):
             raise TypeError("La méthode HTTP doit être une chaine de caractère ou None.")
         # Vérification de la ressource demandée
-        if self.url != None and not isinstance(self.url, str):
+        if self.url is not None and not isinstance(self.url, str):
             raise TypeError("L'URL doit être une chaine de caractère ou None.")
         # Vérification du protocole HTTP
-        if self.protocole_http != None and not isinstance(self.protocole_http, str):
+        if self.protocole_http is not None and not isinstance(self.protocole_http, str):
             raise TypeError("Le protocole HTTP doit être une chaine de caractère ou None.")
         # Vérification de l'ancienne URL
-        if self.ancienne_url != None and not isinstance(self.ancienne_url, str):
+        if self.ancienne_url is not None and not isinstance(self.ancienne_url, str):
             raise TypeError("L'ancienne URL doit être une chaine de caractère ou None.")

--- a/app/donnees/requete_informations.py
+++ b/app/donnees/requete_informations.py
@@ -25,9 +25,6 @@ class RequeteInformations:
             Peut être None si non fournie.
         ancienne_url (Optional[str]): L'URL de provenance (referrer).
             Peut être None si non fournie.
-
-    Raises:
-        TypeError: Si les attributs ne sont pas du type attendu ou None.
     """
     horodatage: datetime
     methode_http: Optional[str]
@@ -36,6 +33,12 @@ class RequeteInformations:
     ancienne_url: Optional[str]
 
     def __post_init__(self):
+        """
+        Vérifie le bon type des données de cette classe lors de l'initialisation de l'instance.
+
+        Raises:
+            TypeError: Une donnée n'est pas du bon type.
+        """
         # Vérification de l'horodatage
         if not isinstance(self.horodatage, datetime):
             raise TypeError("L'horodatage doit être de type datetime.")

--- a/app/donnees/requete_informations.py
+++ b/app/donnees/requete_informations.py
@@ -15,7 +15,7 @@ class RequeteInformations:
     qui concernent les informations techniques sur la requête émise au
     serveur Apache.
 
-    Args:
+    Attributes:
         horodatage (datetime): L'horodatage de la requête.
         methode_http (Optional[str]): La méthode HTTP utilisée.
             Peut être None si non fournie.

--- a/app/export/exporteur.py
+++ b/app/export/exporteur.py
@@ -29,9 +29,12 @@ class Exporteur:
             ExportationDossierParentException: Exportation impossible à cause de
                 l'inexistance du dossier parent du fichier d'exportation.
         """
+        # Vérification du type du paramètre
         if not isinstance(chemin_sortie, str):
             raise TypeError("Le chemin de sortie doit être une chaîne de caractère.")
+        # Vérification du chemin d'exportation
         self.verification_exportation_possible(chemin_sortie)
+        # Ajout du chemin d'exportation
         self._chemin_sortie = chemin_sortie
 
     def verification_exportation_possible(self, chemin_sortie: str) -> None:
@@ -48,6 +51,10 @@ class Exporteur:
         Raises:
             ExportationDossierParentException: Le dossier parent du fichier n'existe pas.
         """
+        # Vérification du type du paramètre
+        if not isinstance(chemin_sortie, str):
+            raise TypeError("Le chemin de sortie doit être une chaîne de caractères.")
+        # Vérification du chemin
         chemin_sortie_absolue = abspath(chemin_sortie)
         dossier_parent = dirname(chemin_sortie_absolue)
         if not isdir(dossier_parent):
@@ -55,7 +62,7 @@ class Exporteur:
                                        f"fichier {chemin_sortie}, son dossier parent "
                                        f"{dossier_parent} n'existe pas.")
 
-    def export_vers_json(self, donnees: dict):
+    def export_vers_json(self, donnees: dict) -> None:
         """
         Export le dictionnaire fourni vers le :attr:`chemin de sortie`.
 
@@ -69,10 +76,11 @@ class Exporteur:
             TypeError: Le paramètre ``donnees`` n'est pas un dictionnaire.
             ExportationException: Une erreur lors de l'écriture dans le fichier JSON.
         """
+        # Vérification du type du paramètre
         if not isinstance(donnees, dict):
             raise TypeError("Les données à exporter doivent être sous une forme "
             "de dictionnaire.")
-
+        # Exportation
         try:
             with open(self._chemin_sortie, 'w', encoding="utf-8") as fichier:
                 dump(donnees, fichier, indent=4)

--- a/app/export/exporteur.py
+++ b/app/export/exporteur.py
@@ -26,18 +26,34 @@ class Exporteur:
         
         Raises:
             TypeError: Le chemin de sortie n'est pas une chaîne de caractère.
-            ExportationException: Exportation impossible à cause de
-                l'emplacement invalide du fichier de sortie.
+            ExportationDossierParentException: Exportation impossible à cause de
+                l'inexistance du dossier parent du fichier d'exportation.
         """
         if not isinstance(chemin_sortie, str):
             raise TypeError("Le chemin de sortie doit être une chaîne de caractère.")
+        self.verification_exportation_possible(chemin_sortie)
+        self._chemin_sortie = chemin_sortie
+
+    def verification_exportation_possible(self, chemin_sortie: str) -> None:
+        """
+        Vérifie qu'une exportation est possible vers le chemin du fichier indiqué. Renvoie une
+        exception expliquant le problème si elle n'est pas possible.
+
+        Args:
+            chemin_sortie (str): Le chemin du fichier d'exportation.
+
+        Returns:
+            None
+
+        Raises:
+            ExportationDossierParentException: Le dossier parent du fichier n'existe pas.
+        """
         chemin_sortie_absolue = abspath(chemin_sortie)
         dossier_parent = dirname(chemin_sortie_absolue)
         if not isdir(dossier_parent):
-            raise ExportationException(f"Impossible d'exporter vers le "
+            raise ExportationDossierParentException(f"Impossible d'exporter vers le "
                                        f"fichier {chemin_sortie}, son dossier parent "
                                        f"{dossier_parent} n'existe pas.")
-        self._chemin_sortie = chemin_sortie
 
     def export_vers_json(self, donnees: dict):
         """
@@ -56,9 +72,9 @@ class Exporteur:
         if not isinstance(donnees, dict):
             raise TypeError("Les données à exporter doivent être sous une forme "
             "de dictionnaire.")
-        
+
         try:
-            with open(self._chemin_sortie, 'w') as fichier:
+            with open(self._chemin_sortie, 'w', encoding="utf-8") as fichier:
                 dump(donnees, fichier, indent=4)
         except Exception as ex:
             raise ExportationException(str(ex)) from ex
@@ -67,6 +83,9 @@ class ExportationException(Exception):
     """
     Représente une erreur lors de l'exportation de données.
     """
-    
-    def __init__(self, *args):
-        super().__init__(*args)
+
+class ExportationDossierParentException(ExportationException):
+    """
+    Représente une erreur lorsque une exportation est impossible
+    lorsque le dossier parent du fichier d'exportation n'existe pas.
+    """

--- a/app/main.py
+++ b/app/main.py
@@ -31,30 +31,31 @@ def main():
         exporteur.export_vers_json(analyse)
         # Termine l'animation de chargement
         afficheur_cli.stop_animation_chargement()
-    except Exception as ex:
-        gestion_exception(afficheur_cli, ex)
+    except ArgumentCLIException as ex:
+        gestion_exception(afficheur_cli, "Erreur dans les arguments fournis !", ex)
+    except FileNotFoundError as ex:
+        gestion_exception(afficheur_cli, "Erreur dans la recherche du log Apache !", ex)
+    except FormatLogApacheInvalideException as ex:
+        gestion_exception(afficheur_cli, "Erreur dans l'analyse du log Apache !", ex)
+    except ExportationException as ex:
+        gestion_exception(afficheur_cli, "Erreur dans l'exportation de l'analyse !", ex)
+    except (ValueError, TypeError) as ex:
+        gestion_exception(afficheur_cli, "Erreur interne !", ex)
 
-def gestion_exception(afficheur_cli, exception):
+def gestion_exception(afficheur_cli, message, exception):
     """
     Gère les erreurs qui demandent une fin du programme.
-    Affiche également un message d'erreur personnalisé en fonction
-    de l'exception.
+    Affiche un message d'erreur personnalisé ainsi que les détails de l'exception.
 
     Args:
         afficheur_cli (AfficheurCLI): L'objet permettant d'intéragir avec la ligne
             de commande.
+        message (str): Message principal à afficher.
         exception (Exception): L'exception qui s'est produite.
 
     Returns:
         None
     """
-    erreurs = {
-        ArgumentCLIException: "Erreur dans les arguments fournis !",
-        FileNotFoundError: "Erreur dans la recherche du log Apache !",
-        FormatLogApacheInvalideException: "Erreur dans l'analyse du log Apache !",
-        ExportationException: "Erreur dans l'exportation de l'analyse !"
-    }
-    message = erreurs.get(type(exception), "Erreur interne !")
     afficheur_cli.stop_animation_chargement(True)
     afficheur_cli.affiche_erreur(message, exception)
 

--- a/app/main.py
+++ b/app/main.py
@@ -8,9 +8,12 @@ from analyse.analyseur_log_apache import AnalyseurLogApache
 from export.exporteur import Exporteur, ExportationException
 
 
-def main():
+def main() -> None:
     """
     Point d'entrée de l'application.
+
+    Returns:
+        None
     """
     afficheur_cli = AfficheurCLI()
     afficheur_cli.affiche_message("Who ya gonna call? LogBuster!")
@@ -40,7 +43,7 @@ def main():
     except (ValueError, TypeError) as ex:
         gestion_exception(afficheur_cli, "Erreur interne !", ex)
 
-def gestion_exception(afficheur_cli, message, exception):
+def gestion_exception(afficheur_cli: AfficheurCLI, message: str, exception: Exception) -> None:
     """
     Gère les erreurs qui demandent une fin du programme.
     Affiche un message d'erreur personnalisé ainsi que les détails de l'exception.

--- a/app/main.py
+++ b/app/main.py
@@ -15,10 +15,11 @@ def main():
     afficheur_cli = AfficheurCLI()
     afficheur_cli.affiche_message("Who ya gonna call? LogBuster!")
     try:
-        afficheur_cli.lance_animation_chargement()
         # Récupération des arguments
         parseur_cli = ParseurArgumentsCLI()
         arguments_cli = parseur_cli.parse_args()
+        # Lance l'animation de chargement
+        afficheur_cli.lance_animation_chargement()
         # Analyse syntaxique du fichier log
         parseur_log = ParseurLogApache(arguments_cli.chemin_log)
         fichier_log = parseur_log.parse_fichier()
@@ -28,6 +29,7 @@ def main():
         # Exportation de l'analyse
         exporteur = Exporteur(arguments_cli.sortie)
         exporteur.export_vers_json(analyse)
+        # Termine l'animation de chargement
         afficheur_cli.stop_animation_chargement()
     except Exception as ex:
         gestion_exception(afficheur_cli, ex)

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ Point d'entrée de l'application LogBuster !
 """
 from cli.afficheur_cli import AfficheurCLI
 from cli.parseur_arguments_cli import ParseurArgumentsCLI, ArgumentCLIException
-from parse.parseur_log_apache import ParseurLogApache, FormatLogApacheInvalideException
+from parse.parseur_log_apache import ParseurLogApache, ParsageLogApacheException
 from analyse.analyseur_log_apache import AnalyseurLogApache
 from export.exporteur import Exporteur, ExportationException
 
@@ -33,9 +33,7 @@ def main():
         afficheur_cli.stop_animation_chargement()
     except ArgumentCLIException as ex:
         gestion_exception(afficheur_cli, "Erreur dans les arguments fournis !", ex)
-    except FileNotFoundError as ex:
-        gestion_exception(afficheur_cli, "Erreur dans la recherche du log Apache !", ex)
-    except FormatLogApacheInvalideException as ex:
+    except ParsageLogApacheException as ex:
         gestion_exception(afficheur_cli, "Erreur dans l'analyse du log Apache !", ex)
     except ExportationException as ex:
         gestion_exception(afficheur_cli, "Erreur dans l'exportation de l'analyse !", ex)

--- a/app/parse/entree_log_apache.py
+++ b/app/parse/entree_log_apache.py
@@ -13,10 +13,10 @@ class EntreeLogApache:
     """
     Représente une entrée dans un fichier de log Apache.
 
-    Args:
-        informations_client (ClientInformations): Les informations du client.
-        informations_requete (RequeteInformations): Les informations de la requête.
-        informations_reponse (ReponseInformations): Les informations de la réponse.
+    Attributes:
+        client (ClientInformations): Les informations du client.
+        requete (RequeteInformations): Les informations de la requête.
+        reponse (ReponseInformations): Les informations de la réponse.
     """
     client: ClientInformations
     requete: RequeteInformations

--- a/app/parse/entree_log_apache.py
+++ b/app/parse/entree_log_apache.py
@@ -1,0 +1,38 @@
+"""
+Module qui contient la classe pour représenter une entrée log Apache.
+"""
+
+from donnees.client_informations import ClientInformations
+from donnees.requete_informations import RequeteInformations
+from donnees.reponse_informations import ReponseInformations
+
+class EntreeLogApache:
+    """
+    Représente une entrée dans un fichier de log Apache.
+
+    Attributes:
+        informations_client (ClientInformations): Les informations du client.
+        informations_requete (RequeteInformations): Les informations de la requête.
+        informations_reponse (ReponseInformations): Les informations de la réponse.
+    """
+    def __init__(self, 
+                 informations_client: ClientInformations,
+                 informations_requete: RequeteInformations,
+                 informations_reponse: ReponseInformations
+                 ):
+
+        # Validation des informations
+        if not isinstance(informations_client, ClientInformations):
+            raise TypeError("Les informations du client dans une entrée doivent être"
+                "regroupées au sein d'un objet ClientInformations.")
+        if not isinstance(informations_client, ClientInformations):
+            raise TypeError("Les informations de la requête dans une entrée doivent être"
+                "regroupées au sein d'un objet RequeteInformations.")
+        if not isinstance(informations_client, ClientInformations):
+            raise TypeError("Les informations de la réponse dans une entrée doivent être"
+                "regroupées au sein d'un objet ReponseInformations.")
+
+        # Récupération des informations
+        self.client = informations_client
+        self.requete = informations_requete
+        self.reponse = informations_reponse

--- a/app/parse/entree_log_apache.py
+++ b/app/parse/entree_log_apache.py
@@ -2,37 +2,40 @@
 Module qui contient la classe pour représenter une entrée log Apache.
 """
 
+from dataclasses import dataclass
 from donnees.client_informations import ClientInformations
 from donnees.requete_informations import RequeteInformations
 from donnees.reponse_informations import ReponseInformations
 
+
+@dataclass
 class EntreeLogApache:
     """
     Représente une entrée dans un fichier de log Apache.
 
-    Attributes:
+    Args:
         informations_client (ClientInformations): Les informations du client.
         informations_requete (RequeteInformations): Les informations de la requête.
         informations_reponse (ReponseInformations): Les informations de la réponse.
     """
-    def __init__(self, 
-                 informations_client: ClientInformations,
-                 informations_requete: RequeteInformations,
-                 informations_reponse: ReponseInformations
-                 ):
+    client: ClientInformations
+    requete: RequeteInformations
+    reponse: ReponseInformations
 
+    def __post_init__(self):
         # Validation des informations
-        if not isinstance(informations_client, ClientInformations):
-            raise TypeError("Les informations du client dans une entrée doivent être"
-                "regroupées au sein d'un objet ClientInformations.")
-        if not isinstance(informations_client, ClientInformations):
-            raise TypeError("Les informations de la requête dans une entrée doivent être"
-                "regroupées au sein d'un objet RequeteInformations.")
-        if not isinstance(informations_client, ClientInformations):
-            raise TypeError("Les informations de la réponse dans une entrée doivent être"
-                "regroupées au sein d'un objet ReponseInformations.")
-
-        # Récupération des informations
-        self.client = informations_client
-        self.requete = informations_requete
-        self.reponse = informations_reponse
+        if not isinstance(self.client, ClientInformations):
+            raise TypeError(
+                "Les informations du client dans une entrée doivent être"
+                "regroupées au sein d'un objet ClientInformations."
+            )
+        if not isinstance(self.requete, RequeteInformations):
+            raise TypeError(
+                "Les informations de la requête dans une entrée doivent être"
+                "regroupées au sein d'un objet RequeteInformations."
+            )
+        if not isinstance(self.reponse, ReponseInformations):
+            raise TypeError(
+                "Les informations de la réponse dans une entrée doivent être"
+                "regroupées au sein d'un objet ReponseInformations."
+            )

--- a/app/parse/entree_log_apache.py
+++ b/app/parse/entree_log_apache.py
@@ -23,6 +23,12 @@ class EntreeLogApache:
     reponse: ReponseInformations
 
     def __post_init__(self):
+        """
+        Vérifie le bon type des données de cette classe lors de l'initialisation de l'instance.
+
+        Raises:
+            TypeError: Une donnée n'est pas du bon type.
+        """
         # Validation des informations
         if not isinstance(self.client, ClientInformations):
             raise TypeError(

--- a/app/parse/fichier_log_apache.py
+++ b/app/parse/fichier_log_apache.py
@@ -19,6 +19,12 @@ class FichierLogApache:
     entrees: list = field(default_factory=list)
 
     def __post_init__(self):
+        """
+        Vérifie le bon type des données de cette classe lors de l'initialisation de l'instance.
+
+        Raises:
+            TypeError: Une donnée n'est pas du bon type.
+        """
         # Validation du chemin
         if not isinstance (self.chemin, str):
             raise TypeError("Le chemin du fichier doit être une chaîne de caractère.")
@@ -36,9 +42,9 @@ class FichierLogApache:
             None
 
         Raises:
-            TypeError: L'entrée n'est pas un objet EntreeLogApache.
+            TypeError: L'entrée ``entree`` n'est pas un objet :class:`EntreeLogApache`.
         """
-        # Validation du paramètre
+        # Vérification du type du paramètre
         if not isinstance (entree, EntreeLogApache):
             raise TypeError("Les informations de l'entrée doivent être dans un objet"
                 "EntreeLogApache.")

--- a/app/parse/fichier_log_apache.py
+++ b/app/parse/fichier_log_apache.py
@@ -1,38 +1,47 @@
 """
-Module qui contient les classes pour représenter un fichier log Apache.
+Module qui contient la classe pour représenter un fichier log Apache.
 """
 
+from dataclasses import dataclass, field
+from parse.entree_log_apache import EntreeLogApache
 
+
+@dataclass
 class FichierLogApache:
     """
     Représente un fichier de log Apache.
+
+    Attributes:
+        chemin (str): Le chemin du fichier.
+        entrees (list): La liste des entrées du fichier.
     """
+    chemin: str
+    entrees: list = field(default_factory=list)
 
-    def __init__(self, chemin):
-        self.chemin = chemin
-        self.entrees = []
+    def __post_init__(self):
+        # Validation du chemin
+        if not isinstance (self.chemin, str):
+            raise TypeError("Le chemin du fichier doit être une chaîne de caractère.")
+        if not isinstance (self.entrees, list):
+            raise TypeError("La liste des entrées doit être une liste.")
 
-    def ajoute_entree(self, entree):
+    def ajoute_entree(self, entree: EntreeLogApache) -> None:
         """
         Ajoute une entrée à la liste des entrées du fichier.
+
         Args:
             entree (EntreeLogApache): L'entrée à ajouter.
+
         Returns:
             None
+
+        Raises:
+            TypeError: L'entrée n'est pas un objet EntreeLogApache.
         """
+        # Validation du paramètre
+        if not isinstance (entree, EntreeLogApache):
+            raise TypeError("Les informations de l'entrée doivent être dans un objet"
+                "EntreeLogApache.")
+
+        # Récupération de l'entrée
         self.entrees.append(entree)
-
-
-
-class EntreeLogApache:
-    """
-    Représente une entrée dans un fichier de log Apache.
-    """
-    def __init__(self, 
-                 informations_client,
-                 informations_requete,
-                 informations_reponse
-                 ):
-        self.client = informations_client
-        self.requete = informations_requete
-        self.reponse = informations_reponse

--- a/app/parse/fichier_log_apache.py
+++ b/app/parse/fichier_log_apache.py
@@ -11,7 +11,7 @@ class FichierLogApache:
     """
     Représente un fichier de log Apache.
 
-    Args:
+    Attributes:
         chemin (str): Le chemin du fichier.
         entrees (list): La liste des entrées du fichier.
     """

--- a/app/parse/fichier_log_apache.py
+++ b/app/parse/fichier_log_apache.py
@@ -11,7 +11,7 @@ class FichierLogApache:
     """
     Représente un fichier de log Apache.
 
-    Attributes:
+    Args:
         chemin (str): Le chemin du fichier.
         entrees (list): La liste des entrées du fichier.
     """

--- a/app/parse/parseur_log_apache.py
+++ b/app/parse/parseur_log_apache.py
@@ -38,10 +38,10 @@ class ParseurLogApache():
             chemin_log (str): Le chemin du fichier à analyser.
 
         Raises:
-            FileNotFoundError: Si le fichier à analyser est introuvable.
+            FichierLogApacheIntrouvableException: Si le fichier à analyser est introuvable.
         """
         if not os.path.isfile(chemin_log):
-            raise FileNotFoundError(f"Le fichier {chemin_log} est introuvable.")
+            raise FichierLogApacheIntrouvableException(f"Le fichier {chemin_log} est introuvable.")
         self.chemin_log = chemin_log
 
     def parse_fichier(self):
@@ -202,10 +202,22 @@ class ParseurLogApache():
         valeur = analyse_regex.get(nom_information)
         return valeur if valeur not in ("", "-") else None
 
-class FormatLogApacheInvalideException(Exception):
+class ParsageLogApacheException(Exception):
+    """
+    Exception représentant une erreur lors du parsage du fichier
+    de log Apache.
+    """
+    def __init__(self, *args):
+        super().__init__(*args)
+
+class FichierLogApacheIntrouvableException(ParsageLogApacheException):
+    """
+    Exception représentant une erreur lorsque le fichier de log Apache
+    est introuvable.
+    """
+
+class FormatLogApacheInvalideException(ParsageLogApacheException):
     """
     Exception représentant une erreur dans le format du fichier
     de log Apache fourni.
     """
-    def __init__(self, *args):
-        super().__init__(*args)

--- a/app/parse/parseur_log_apache.py
+++ b/app/parse/parseur_log_apache.py
@@ -5,7 +5,8 @@ Module pour parser un fichier log Apache.
 import os
 from re import match
 from datetime import datetime
-from parse.fichier_log_apache import FichierLogApache, EntreeLogApache
+from parse.fichier_log_apache import FichierLogApache
+from parse.entree_log_apache import EntreeLogApache
 from donnees.client_informations import ClientInformations
 from donnees.requete_informations import RequeteInformations
 from donnees.reponse_informations import ReponseInformations

--- a/app/parse/parseur_log_apache.py
+++ b/app/parse/parseur_log_apache.py
@@ -97,8 +97,8 @@ class ParseurLogApache():
             FormatLogApacheInvalideException: Format de l'entrée du fichier log invalide.
         """
         # Vérification du type du paramètre
-        if not isinstance(entree, EntreeLogApache):
-            raise TypeError("L'entrée doit être représentée avec un objet EntreeLogApache")
+        if not isinstance(entree, str):
+            raise TypeError("L'entrée doit être représentée sous forme de chaîne de caractères.")
 
         # Analyse de l'entrée
         analyse = match(self.PATTERN_ENTREE_LOG_APACHE, entree)

--- a/app/parse/parseur_log_apache.py
+++ b/app/parse/parseur_log_apache.py
@@ -18,8 +18,8 @@ class ParseurLogApache():
     Représente un parseur pour faire une analyse synthaxique d'un fichier
     log Apache.
 
-    Attributes:
-        PATTERN_ENTREE_LOG_APACHE (str): Le pattern regex d'une entrée dans un log Apache.
+    Class-level variables:
+        :cvar PATTERN_ENTREE_LOG_APACHE (str): Le pattern regex d'une entrée dans un log Apache.
     """
 
     PATTERN_ENTREE_LOG_APACHE: str = (
@@ -229,9 +229,11 @@ class ParseurLogApache():
             nom_information (str): Nom de l'information souhaitée.
         
         Returns:
-            TypeError: Un paramètre n'a pas le bon type.
             Optional[str]: La valeur sous forme de chaîne de caractère ou None si
                 aucune valeur n'a été trouvée.
+
+        Raises:
+            TypeError: Un paramètre n'a pas le bon type.
         """
         # Vérification du type des paramètres
         if not isinstance(analyse_regex, dict):

--- a/app/parse/parseur_log_apache.py
+++ b/app/parse/parseur_log_apache.py
@@ -5,6 +5,7 @@ Module pour parser un fichier log Apache.
 import os
 from re import match
 from datetime import datetime
+from typing import Optional
 from parse.fichier_log_apache import FichierLogApache
 from parse.entree_log_apache import EntreeLogApache
 from donnees.client_informations import ClientInformations
@@ -21,7 +22,7 @@ class ParseurLogApache():
         PATTERN_ENTREE_LOG_APACHE (str): Le pattern regex d'une entrée dans un log Apache.
     """
 
-    PATTERN_ENTREE_LOG_APACHE = (
+    PATTERN_ENTREE_LOG_APACHE: str = (
         r'(?P<ip>\S+) (?P<rfc>\S+) (?P<utilisateur>\S+)'
         r' (\[(?P<horodatage>\d{2}\/\w{3}\/\d{4}:\d{1,2}:\d{1,2}:\d{1,2} \+\d{4})\]|-)'
         r' "((?P<methode>\S+) (?P<url>\S+) (?P<protocole>\S+)|-)"'
@@ -38,13 +39,19 @@ class ParseurLogApache():
             chemin_log (str): Le chemin du fichier à analyser.
 
         Raises:
+            TypeError: Le chemin ``chemin_log`` n'est pas de type ``str``.
             FichierLogApacheIntrouvableException: Si le fichier à analyser est introuvable.
         """
+        # Vérification du type du paramètre
+        if not isinstance(chemin_log, str):
+            raise TypeError("Le chemin du log doit être une chaîne de caractères.")
+        # Vérification du chemin
         if not os.path.isfile(chemin_log):
             raise FichierLogApacheIntrouvableException(f"Le fichier {chemin_log} est introuvable.")
+        # Ajout du chemin
         self.chemin_log = chemin_log
 
-    def parse_fichier(self):
+    def parse_fichier(self) -> FichierLogApache:
         """
         Effectue une analyse syntaxique du fichier de log Apache puis retourne
         une représentation du fichier avec les informations trouvées.
@@ -55,10 +62,14 @@ class ParseurLogApache():
         Raises:
             FormatLogApacheInvalideException: Format du fichier log invalide.
         """
+        # Initialisation de la représentation du fichier
         log_analyse = FichierLogApache(self.chemin_log)
+        # Ouverture du log
         with open(self.chemin_log, "r", encoding="utf-8") as log:
+            # Parcours des entrées du log
             for numero_ligne, ligne in enumerate(log, start=1):
                 try:
+                    # Parsage de l'entrée
                     entree = self.parse_entree(ligne)
                     log_analyse.ajoute_entree(entree)
                 except FormatLogApacheInvalideException as ex:
@@ -69,7 +80,7 @@ class ParseurLogApache():
 
         return log_analyse
 
-    def parse_entree(self, entree):
+    def parse_entree(self, entree: str) -> EntreeLogApache:
         """
         Effectue une analyse syntaxique d'une entrée dans un fichier de log
         Apache puis retourne une représentation de l'entrée avec les
@@ -82,8 +93,13 @@ class ParseurLogApache():
             entree_analysee (EntreeLogApache): Représentation de l'entrée.
 
         Raises:
+            TypeError: L'entrée ``entree`` n'est pas de type :class:`EntreeLogApache`
             FormatLogApacheInvalideException: Format de l'entrée du fichier log invalide.
         """
+        # Vérification du type du paramètre
+        if not isinstance(entree, EntreeLogApache):
+            raise TypeError("L'entrée doit être représentée avec un objet EntreeLogApache")
+
         # Analyse de l'entrée
         analyse = match(self.PATTERN_ENTREE_LOG_APACHE, entree)
         if not analyse:
@@ -117,8 +133,13 @@ class ParseurLogApache():
             ClientInformations: Les informations du client.
 
         Raises:
+            TypeError: L'analyse ``analyse_regex`` n'est pas un ``dict``.
             FormatLogApacheInvalideException: L'adresse IP n'est pas présente dans l'analyse.
         """
+        # Vérification du type du paramètre
+        if not isinstance(analyse_regex, dict):
+            raise TypeError("L'analyse du regex doit être un dictionnaire.")
+
         # Adresse IP
         adresse_ip = self.get_information_entree(analyse_regex, "ip")
         if adresse_ip is None:
@@ -142,11 +163,16 @@ class ParseurLogApache():
             analyse_regex (dict): Analyse regex d'une entrée.
 
         Returns:
-            ClientInformations: Les informations de la requête.
+            RequeteInformations: Les informations de la requête.
 
         Raises:
+            TypeError: L'analyse ``analyse_regex`` n'est pas un ``dict``.
             FormatLogApacheInvalideException: L'horodatage n'est pas présente dans l'analyse.
         """
+        # Vérification du type du paramètre
+        if not isinstance(analyse_regex, dict):
+            raise TypeError("L'analyse du regex doit être un dictionnaire.")
+
         # Horodatage
         horodatage = self.get_information_entree(analyse_regex, "horodatage")
         if horodatage:
@@ -174,8 +200,13 @@ class ParseurLogApache():
             analyse_regex (dict): Analyse regex d'une entrée.
 
         Returns:
-            ClientInformations: Les informations de la réponse.
+            TypeError: L'analyse ``analyse_regex`` n'est pas un ``dict``.
+            ReponseInformations: Les informations de la réponse.
         """
+        # Vérification du type du paramètre
+        if not isinstance(analyse_regex, dict):
+            raise TypeError("L'analyse du regex doit être un dictionnaire.")
+
         # Code de statut
         code_statut = self.get_information_entree(analyse_regex, "code_status")
         code_statut = int(code_statut)
@@ -188,17 +219,27 @@ class ParseurLogApache():
             code_statut, taille_octets
         )
 
-    def get_information_entree(self, analyse_regex: dict, nom_information: str):
+    def get_information_entree(self, analyse_regex: dict, nom_information: str) -> Optional[str]:
         """
         Retourne la valeur de l'information dans l'analyse si elle possède une valeur
         ou None si elle ne possède pas de valeur (égale à - ou vide).
+
         Args:
             analyse_regex (Match[str]): Résultat du regex de l'analyse.
             nom_information (str): Nom de l'information souhaitée.
+        
         Returns:
-            Union[str, None]: La valeur sous forme de chaîne de caractère ou None si
+            TypeError: Un paramètre n'a pas le bon type.
+            Optional[str]: La valeur sous forme de chaîne de caractère ou None si
                 aucune valeur n'a été trouvée.
         """
+        # Vérification du type des paramètres
+        if not isinstance(analyse_regex, dict):
+            raise TypeError("L'analyse du regex doit être un dictionnaire.")
+        if not isinstance(nom_information, str):
+            raise TypeError("Le nom de l'information doit être une chaîne de caractères.")
+
+        # Récupération de l'information
         valeur = analyse_regex.get(nom_information)
         return valeur if valeur not in ("", "-") else None
 

--- a/docs/source/modules/donnees/client_informations.rst
+++ b/docs/source/modules/donnees/client_informations.rst
@@ -5,3 +5,4 @@ ClientInformations
    :members:
    :show-inheritance:
    :undoc-members:
+   :exclude-members: adresse_ip, identifiant_rfc, nom_utilisateur, agent_utilisateur

--- a/docs/source/modules/donnees/reponse_informations.rst
+++ b/docs/source/modules/donnees/reponse_informations.rst
@@ -5,3 +5,4 @@ ReponseInformations
    :members:
    :show-inheritance:
    :undoc-members:
+   :exclude-members: code_statut_http, taille_octets

--- a/docs/source/modules/donnees/requete_informations.rst
+++ b/docs/source/modules/donnees/requete_informations.rst
@@ -5,4 +5,4 @@ RequeteInformations
    :members:
    :show-inheritance:
    :undoc-members:
-   :exclude-members: dataclass
+   :exclude-members: horodatage, methode_http, url, protocole_http, ancienne_url

--- a/docs/source/modules/parse/entree_log_apache.rst
+++ b/docs/source/modules/parse/entree_log_apache.rst
@@ -5,3 +5,4 @@ EntreeLogApache
    :members:
    :show-inheritance:
    :undoc-members:
+   :exclude-members: client, requete, reponse

--- a/docs/source/modules/parse/entree_log_apache.rst
+++ b/docs/source/modules/parse/entree_log_apache.rst
@@ -1,0 +1,7 @@
+EntreeLogApache
+======================
+
+.. automodule:: parse.entree_log_apache
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/modules/parse/fichier_log_apache.rst
+++ b/docs/source/modules/parse/fichier_log_apache.rst
@@ -5,3 +5,4 @@ FichierLogApache
    :members:
    :show-inheritance:
    :undoc-members:
+   :exclude-members: chemin, entrees

--- a/docs/source/modules/parse/index_parse.rst
+++ b/docs/source/modules/parse/index_parse.rst
@@ -6,3 +6,4 @@ Parse
 
    parseur_log_apache.rst
    fichier_log_apache.rst
+   entree_log_apache.rst

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,8 +113,8 @@ def parseur_log_apache(log_apache, request):
         ParseurLogApache: Une instance de la classe :class:`ParseurLogApache`.
     """
     if hasattr(request, "param") and request.param == False:
-        return ParseurLogApache(log_apache(False))
-    return ParseurLogApache(log_apache(True))
+        return ParseurLogApache(str(log_apache(False)))
+    return ParseurLogApache(str(log_apache(True)))
 
 @pytest.fixture()
 def fichier_log_apache(parseur_log_apache):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,8 +140,8 @@ def entree_log_apache(fichier_log_apache):
     ``lignes_valides``.
 
     Args:
-        fichier_log_apache (FichierLogApache): Fixture pour l'instance 
-            de la classe :class:`FichierLogApache`.
+        fichier_log_apache (EntreeLogApache): Fixture pour l'instance 
+            de la classe :class:`EntreeLogApache`.
 
     Returns:
         EntreeLogApache: Une instance de la classe :class:`EntreeLogApache`.

--- a/tests/test_afficheur_cli.py
+++ b/tests/test_afficheur_cli.py
@@ -169,6 +169,23 @@ def test_afficheur_cli_lance_animation_chargement(mocker, afficheur_cli):
     assert afficheur_cli._thread_chargement is not None
     assert afficheur_cli._thread_chargement.is_alive()
 
+def test_afficheur_cli_exception_stop_animation_chargment_type_invalide(afficheur_cli):
+    """
+    Vérifie que la méthode stop_animation_chargement renvoie une erreur lorsque le type
+    de son paramètre est invalide.
+
+    Scénarios testés:
+        - Paramètre ``erreur`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        afficheur_cli (AfficheurCLI): Fixture pour l'instance de la classe ``AfficheurCLI``.
+    """
+    with pytest.raises(TypeError):
+        afficheur_cli.stop_animation_chargement("False")
+
 def test_afficheur_cli_stop_animation_chargement_terminee(afficheur_cli):
     """
     Vérifie que la méthode stop_animation_chargement arrête correctement l'animation en

--- a/tests/test_exporteur.py
+++ b/tests/test_exporteur.py
@@ -40,10 +40,27 @@ def test_exporteur_emplacement_inexistant():
     with pytest.raises(ExportationException):
         exporteur = Exporteur("dossier/inexistant/sortie.json")
 
+def test_exporteur_verification_exception_exportation_possible_type_invalide(exporteur):
+    """
+    Vérifie que la méthode verification_exportation_possible renvoie une erreur lorsque le type
+    de son paramètre est invalide.
+
+    Scénarios testés:
+        - Paramètre ``chemin_sortie`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        exporteur (Exporteur) : Fixture pour l'instance de la classe :class:`Exporteur`.
+    """
+    with pytest.raises(TypeError):
+        exporteur.verification_exportation_possible(False)
+
 @pytest.mark.parametrize("donnees", [
     (0), (None), ([])
 ])
-def test_exportateur_export_json_type_donnees_invalide(exporteur, donnees):
+def test_exporteur_export_json_type_donnees_invalide(exporteur, donnees):
     """
     Vérifie que la classe renvoie une erreur lorsque un argument de type invalide
     est passé dans la méthode ``export_vers_json``.
@@ -66,7 +83,7 @@ def test_exportateur_export_json_type_donnees_invalide(exporteur, donnees):
     (FileNotFoundError("Fichier non trouvé.")),
     (Exception("Toutes exceptions"))
 ])
-def test_exportateur_export_json_exception_exportation(exporteur, mocker, exception):
+def test_exporteur_export_json_exception_exportation(exporteur, mocker, exception):
     """
     Vérifie que la classe renvoie l'exception :class:`ExportationException` lorsque
     une erreur apparait durant l'exportation des données.
@@ -88,7 +105,7 @@ def test_exportateur_export_json_exception_exportation(exporteur, mocker, except
     with pytest.raises(ExportationException):
         exporteur.export_vers_json({})
 
-def test_exportateur_exportation_json_valide(exporteur, fichier_json):
+def test_exporteur_exportation_json_valide(exporteur, fichier_json):
     """
     Vérifie que la méthode ``export_vers_json`` exporte correctement les données
     vers une fichier.

--- a/tests/test_fichier_entree_log_apache.py
+++ b/tests/test_fichier_entree_log_apache.py
@@ -1,0 +1,86 @@
+"""
+Module des tests unitaires pour la classe de représentation d'un fichier de log
+ou celle d'une entrée d'un log.
+"""
+
+import pytest
+from datetime import datetime
+from parse.fichier_log_apache import FichierLogApache
+from parse.entree_log_apache import EntreeLogApache
+from donnees.client_informations import ClientInformations
+from donnees.requete_informations import RequeteInformations
+from donnees.reponse_informations import ReponseInformations
+
+
+@pytest.mark.parametrize("chemin, entrees", [
+    (False, []),
+    ("Chemin", False)
+])
+def test_fichier_log_exception_type_invalide(chemin, entrees):
+    """
+    Vérifie que l'initialisation d'un FichierLogApache renvoie une erreur lorsque le type
+    de son paramètre est invalide.
+
+    Scénarios testés:
+        - Paramètre ``chemin`` avec un mauvais type.
+        - Paramètre ``entrees`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        chemin (any): Le chemin du fichier.
+        entrees (any): Les entrées du fichier.
+    """
+    with pytest.raises(TypeError):
+        fichier = FichierLogApache(chemin, entrees)
+
+def test_fichier_log_exception_ajoute_entree_type_invalide(fichier_log_apache):
+    """
+    Vérifie que la méthode ajoute_entree retourne une erreur lorsque son paramètre
+    n'est pas du type attendu.
+
+    Scénarios testés:
+        - Paramètre ``entree`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        fichier_log_apache (FichierLogApache): Fixture pour l'instance 
+            de la classe :class:`FichierLogApache`.
+    """
+    with pytest.raises(TypeError):
+        fichier_log_apache.ajoute_entree(False)
+
+@pytest.mark.parametrize("client, requete, reponse", [
+    (False,
+     RequeteInformations(datetime(1, 1, 1), "GET", "/", "HTTP/1.1", "/"),
+     ReponseInformations(0, 0)),
+    (ClientInformations("1.1.1.1", "RFC", "test", "google"),
+     False,
+     ReponseInformations(0, 0)),
+    (ClientInformations("1.1.1.1", "RFC", "test", "google"),
+     RequeteInformations(datetime(1, 1, 1), "GET", "/", "HTTP/1.1", "/"),
+     False)
+])
+def test_entree_log_exception_type_invalide(client, requete, reponse):
+    """
+    Vérifie que l'initialisation d'un EntreeLogApache renvoie une erreur lorsque le type
+    de son paramètre est invalide.
+
+    Scénarios testés:
+        - Paramètre ``client`` avec un mauvais type.
+        - Paramètre ``requete`` avec un mauvais type.
+        - Paramètre ``reponse`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        client (any): Les informations du client sur cette entrée.
+        requete (any): Les informations de la requête sur cette entrée.
+        reponse (any): Les informations de la réponse sur cette entrée.
+    """
+    with pytest.raises(TypeError):
+        entree = EntreeLogApache(client, requete, reponse)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,22 +3,25 @@ Module des tests unitaires pour le point d'entrée de l'application.
 """
 
 import pytest
-import sys
 from main import main
 from cli.parseur_arguments_cli import ArgumentCLIException
 from parse.parseur_log_apache import FormatLogApacheInvalideException
 from export.exporteur import ExportationException
 
-@pytest.mark.parametrize("exception", [
-    (ArgumentCLIException),
-    (FileNotFoundError),
-    (FormatLogApacheInvalideException),
-    (ExportationException),
-    (Exception)
-])
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        (ArgumentCLIException),
+        (FormatLogApacheInvalideException),
+        (ExportationException),
+        (TypeError),
+        (ValueError),
+    ],
+)
 def test_main_gestion_exception(mocker, exception):
     """
-    Vérifie que les exceptions sont interceptées dans fichier principal.
+    Vérifie que les exceptions attendues sont interceptées dans fichier principal.
 
     Scénarios testés:
         - Vérification que les exceptions n'arrête pas le programme.
@@ -45,16 +48,20 @@ def test_main_succes(mocker):
     """
     # Mock des classes pour simuler un fonctionnement correct
     mock_parseur_cli = mocker.patch("main.ParseurArgumentsCLI")
-    mock_parseur_cli.return_value.parse_args.return_value = mocker.MagicMock(chemin_log="test.log")
-    
+    mock_parseur_cli.return_value.parse_args.return_value = mocker.MagicMock(
+        chemin_log="test.log"
+    )
+
     mock_parseur_log = mocker.patch("main.ParseurLogApache")
     mock_parseur_log.return_value.parse_fichier.return_value = mocker.MagicMock()
-    
+
     mock_analyseur_log = mocker.patch("main.AnalyseurLogApache")
-    mock_analyseur_log.return_value.get_analyse_complete.return_value = {"chemin": "test.log"}
+    mock_analyseur_log.return_value.get_analyse_complete.return_value = {
+        "chemin": "test.log"
+    }
 
     mocker.patch("main.Exporteur")
-    
+
     # Vérifie qu'aucune exception n'est levée
     try:
         main()

--- a/tests/test_parseur_arguments_cli.py
+++ b/tests/test_parseur_arguments_cli.py
@@ -36,6 +36,31 @@ arguments_invalides = [
 
 # Tests unitaires
 
+@pytest.mark.parametrize("args, namespace", [
+    (False, None),
+    (None, False)
+])
+def test_parseur_cli_exception_parse_args_type_invalide(parseur_arguments_cli, args, namespace):
+    """
+    Vérifie que la méthode parse_args renvoie une erreur lorsque le type
+    d'un de ses paramètres est invalide.
+
+    Scénarios testés:
+        - Paramètre ``args`` avec un mauvais type.
+        - Paramètre ``namespace`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurArgumentsCLI`.
+        args (Optional[list]): Une liste avec des arguments.
+        namespace (Optional[Namespace]): L'espace de nom où stocker les arguments.
+    """
+    with pytest.raises(TypeError):
+        parseur_arguments_cli.parse_args(args, namespace)
+
 @pytest.mark.parametrize("arguments", arguments_invalides)
 def test_parseur_cli_exception_argument_inconnu(parseur_arguments_cli, arguments):
     """

--- a/tests/test_parseur_log_apache.py
+++ b/tests/test_parseur_log_apache.py
@@ -6,10 +6,26 @@ import pytest
 from re import match
 from datetime import datetime, timezone, timedelta
 from conftest import lignes_valides, lignes_invalides
-from parse.parseur_log_apache import ParseurLogApache, FormatLogApacheInvalideException
+from parse.parseur_log_apache import (ParseurLogApache, 
+                                      FormatLogApacheInvalideException,
+                                      FichierLogApacheIntrouvableException)
 
 
 # Tests unitaires
+
+def test_parseur_log_exception_type_invalide():
+    """
+    Vérifie que l'initialisation d'un ParseurLogApache renvoie une erreur lorsque le type
+    de son paramètre est invalide.
+
+    Scénarios testés:
+        - Paramètre ``chemin_log`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+    """
+    with pytest.raises(TypeError):
+        ParseurLogApache(False)
 
 def test_parseur_log_exception_fichier_introuvable():
     """
@@ -22,7 +38,7 @@ def test_parseur_log_exception_fichier_introuvable():
     Asserts:
         - Une exception :class:`FileNotFoundError` est levée.
     """
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(FichierLogApacheIntrouvableException):
         parseur = ParseurLogApache("fichier/existe/pas.txt")
 
 @pytest.mark.parametrize("parseur_log_apache", [False], indirect=["parseur_log_apache"])
@@ -43,6 +59,24 @@ def test_parseur_log_exception_fichier_invalide(parseur_log_apache):
     """
     with pytest.raises(FormatLogApacheInvalideException):
         fichier = parseur_log_apache.parse_fichier()
+
+def test_parseur_log_exception_parse_entree_type_invalide(parseur_log_apache):
+    """
+    Vérifie que la méthode parse_entree renvoie une erreur lorsque le type
+    de son paramètre est invalide.
+
+    Scénarios testés:
+        - Paramètre ``entree`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurLogApache`.
+    """
+    with pytest.raises(TypeError):
+        parseur_log_apache.parse_entree(False)
 
 @pytest.mark.parametrize("ligne_invalide", lignes_invalides)
 def test_parseur_log_exception_entree_invalide(parseur_log_apache, ligne_invalide):
@@ -80,6 +114,32 @@ def test_parseur_log_nombre_entrees_valide(parseur_log_apache):
     """
     fichier_log = parseur_log_apache.parse_fichier()
     assert len(fichier_log.entrees) == len(lignes_valides)
+
+@pytest.mark.parametrize("analyse_regex, nom_information", [
+    (False, "Information"),
+    ({}, False)
+])
+def test_parseur_log_apache_exception_get_information_entree_type_invalide(
+        parseur_log_apache, analyse_regex, nom_information):
+    """
+    Vérifie que la méthode get_information_entree renvoie une erreur lorsque le type
+    d'un de ses paramètres est invalide.
+
+    Scénarios testés:
+        - Paramètre ``analyse_regex`` avec un mauvais type.
+        - Paramètre ``nom_information`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurLogApache`.
+        analyse_regex (any): L'analyse de l'entrée par un regex.
+        nom_informations (any): Nom de l'information à récupérer.
+    """
+    with pytest.raises(TypeError):
+        parseur_log_apache.get_information_entree(analyse_regex, nom_information)
 
 @pytest.mark.parametrize("nom_information, retour_attendu", [
     ("ip", "192.168.1.1"),
@@ -143,3 +203,57 @@ def test_parsage_entree_valide(parseur_log_apache):
     assert entree.requete.ancienne_url == "/home"
     assert entree.reponse.code_statut_http == 200
     assert entree.reponse.taille_octets == 532
+
+def test_parseur_log_exception_extraction_informations_client_type_invalide(parseur_log_apache):
+    """
+    Vérifie que la méthode _extraire_informations_client renvoie une erreur lorsque le type
+    de son paramètre est invalide.
+
+    Scénarios testés:
+        - Paramètre ``analyse_regex`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurLogApache`.
+    """
+    with pytest.raises(TypeError):
+        parseur_log_apache._extraire_informations_client(False)
+
+def test_parseur_log_exception_extraction_informations_requete_type_invalide(parseur_log_apache):
+    """
+    Vérifie que la méthode _extraire_informations_requete renvoie une erreur lorsque le type
+    de son paramètre est invalide.
+
+    Scénarios testés:
+        - Paramètre ``analyse_regex`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurLogApache`.
+    """
+    with pytest.raises(TypeError):
+        parseur_log_apache._extraire_informations_requete(False)
+
+def test_parseur_log_exception_extraction_informations_reponse_type_invalide(parseur_log_apache):
+    """
+    Vérifie que la méthode _extraire_informations_reponse renvoie une erreur lorsque le type
+    de son paramètre est invalide.
+
+    Scénarios testés:
+        - Paramètre ``analyse_regex`` avec un mauvais type.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurLogApache`.
+    """
+    with pytest.raises(TypeError):
+        parseur_log_apache._extraire_informations_reponse(False)


### PR DESCRIPTION
- Mise en conformité du code avec PEP8
- Déplacement de la classe EntreeLogApache vers le fichier entree_log_apache.py
- Mise à jour de la documentation suite à ces modifications
- Mise à jour des tests unitaires suite à ces modifications
- Ajout d'une action pour tester si la qualité du code est noté correctement par PyLint (>= 9)