### PR TITLE
Feat: Filtre

### DIFF
--- a/app/analyse/analyseur_log_apache.py
+++ b/app/analyse/analyseur_log_apache.py
@@ -128,7 +128,7 @@ class AnalyseurLogApache:
         return {
             "chemin": self.fichier.chemin,
             "total_entrees": self.get_total_entrees(),
-            "filtre": self.filtre.get_dict_filtres(),
+            "filtre": self.filtre.get_dict_filtre(),
             "statistiques": {
                 "total_entrees_filtre": self.get_total_entrees_filtre(),
                 "requetes": {

--- a/app/analyse/analyseur_log_apache.py
+++ b/app/analyse/analyseur_log_apache.py
@@ -4,6 +4,7 @@ Module pour l'analyse statistique d'un fichier log Apache.
 
 from collections import Counter
 from parse.fichier_log_apache import FichierLogApache
+from analyse.filtre_log_apache import FiltreLogApache
 
 
 class AnalyseurLogApache:
@@ -17,24 +18,29 @@ class AnalyseurLogApache:
             les statistiques des classements (tops).
     """
 
-    def __init__(self, fichier_log_apache: FichierLogApache, nombre_par_top: int = 3):
+    def __init__(self,
+                 fichier_log_apache: FichierLogApache,
+                 filtre: FiltreLogApache,
+                 nombre_par_top: int = 3):
         """
         Initialise un nouveau analysateur de fichier log Apache.
 
         Args:
             fichier_log_apache (FichierLogApache): Le fichier à analyser.
+            filtre (FiltreLogApache): Le filtre à appliquer dans l'analyse. Si une entrée ne
+                passe pas le filtre, elle ne sera pas pris en compte dans l'analyse.
             nombre_par_top (int): Le nombre maximal d'éléments à inclure dans
                 les statistiques des classements (tops). Par défaut, sa valeur est égale à ``3``.
 
         Raises:
-            TypeError: Si l'argument ``fichier_log_apache`` n'est pas une instance 
-                de :class:`FichierLogApache`
-                ou si l'argument ``nombre_par_top`` n'est pas un entier.
+            TypeError: Les paramètres ne sont pas du type attendu.
             ValueError: Si l'argument ``nombre_par_top`` est inférieur à ``0``.
         """
         # Vérification du type des paramètres
         if not isinstance(fichier_log_apache, FichierLogApache):
             raise TypeError("La représentation du fichier doit être de type FichierLogApache.")
+        if not isinstance(filtre, FiltreLogApache):
+            raise TypeError("Le filtre à appliquer aux entrées doit être de type FiltreLogApache.")
         if not isinstance(nombre_par_top, int) or isinstance(nombre_par_top, bool):
             raise TypeError("Le nombre par top doit être un entier.")
         # Vérification de la valeur du paramètre
@@ -43,7 +49,21 @@ class AnalyseurLogApache:
 
         # Ajout des données
         self.fichier = fichier_log_apache
+        self.filtre = filtre
         self.nombre_par_top = nombre_par_top
+
+    def _get_entrees_passent_filtre(self) -> list:
+        """
+        Retourne les entrées qui passent le filtre.
+
+        Returns:
+            list: La liste des entrées qui passent le filtre.
+        """
+        entrees_valides = []
+        for entree in self.fichier.entrees:
+            if self.filtre.entree_passe_filtre(entree):
+                entrees_valides.append(entree)
+        return entrees_valides
 
     def _get_repartition_elements(self,
                           liste_elements: list,
@@ -94,19 +114,23 @@ class AnalyseurLogApache:
 
         L'analyse suit la structure suivante :
             - chemin: chemin du fichier
+            - total_entrees: voir :meth:`get_total_entrees`
+            - filtre: filtre appliqué à l'analyse
             - statistiques:
-                        - requetes:
-                            - top_urls: voir :meth:`get_top_urls`
-                            - repartition_code_statut_http: 
-                                voir :meth:`get_total_par_code_statut_http`
+                - total_entrees_filtre: voir :meth:`get_total_entrees_filtre`
+                - requetes:
+                    - top_urls: voir :meth:`get_top_urls`
+                    - repartition_code_statut_http: voir :meth:`get_total_par_code_statut_http`
 
         Returns:
             dict: L'analyse sous forme d'un dictionnaire.
         """
         return {
             "chemin": self.fichier.chemin,
+            "total_entrees": self.get_total_entrees(),
+            "filtre": self.filtre.get_dict_filtres(),
             "statistiques": {
-                "total_entrees": self.get_total_entrees(),
+                "total_entrees_filtre": self.get_total_entrees_filtre(),
                 "requetes": {
                     "top_urls": self.get_top_urls(),
                     "repartition_code_statut_http": self.get_total_par_code_statut_http()
@@ -122,10 +146,20 @@ class AnalyseurLogApache:
             int: Le nombre total d'entrées.
         """
         return len(self.fichier.entrees)
+    
+    def get_total_entrees_filtre(self) -> int:
+        """
+        Retourne le nombre d'entrées qui ont passées le filtre dans le fichier.
+
+        Returns:
+            int: Le nombre total d'entrées.
+        """
+        return len(self._get_entrees_passent_filtre())
 
     def get_top_urls(self) -> list:
         """
         Retourne le top :attr:`nombre_par_top` des urls les plus demandées.
+        Les entrées prisent en compte sont uniquement celles qui ont passées le filtre.
 
         Returns:
             list: Une liste de dictionnaires où chaque clé contient :
@@ -136,7 +170,7 @@ class AnalyseurLogApache:
                 La liste est triée dans l'ordre décroissant du nombre total d'apparitions.
         """
         return self._get_repartition_elements(
-            [entree.requete.url for entree in self.fichier.entrees],
+            [entree.requete.url for entree in self._get_entrees_passent_filtre()],
             "url",
             True
         )
@@ -144,6 +178,7 @@ class AnalyseurLogApache:
     def get_total_par_code_statut_http(self) -> list:
         """
         Retourne la répartition des réponses par code de statut htpp retourné.
+        Les entrées prisent en compte sont uniquement celles qui ont passées le filtre.
 
         Returns:
             list: Une liste de dictionnaires où chaque clé contient :
@@ -154,6 +189,6 @@ class AnalyseurLogApache:
                 La liste est triée dans l'ordre décroissant du nombre total d'apparitions.
         """
         return self._get_repartition_elements(
-            [entree.reponse.code_statut_http for entree in self.fichier.entrees],
+            [entree.reponse.code_statut_http for entree in self._get_entrees_passent_filtre()],
             "code"
         )

--- a/app/analyse/analyseur_log_apache.py
+++ b/app/analyse/analyseur_log_apache.py
@@ -146,7 +146,7 @@ class AnalyseurLogApache:
             int: Le nombre total d'entrées.
         """
         return len(self.fichier.entrees)
-    
+
     def get_total_entrees_filtre(self) -> int:
         """
         Retourne le nombre d'entrées qui ont passées le filtre dans le fichier.

--- a/app/analyse/filtre_log_apache.py
+++ b/app/analyse/filtre_log_apache.py
@@ -18,7 +18,7 @@ class FiltreLogApache:
             pour pouvoir passer le filtre. Si sa valeur est ``None``, ce filtre ne sera
             pas appliqué.
     """
-    
+
     def __init__(self, filtre_adresse_ip: Optional[str], filtre_code_statut_http: Optional[int]):
         """
         Initalise le filtre à appliquer lors d'une analyse.
@@ -66,13 +66,13 @@ class FiltreLogApache:
         if self.adresse_ip is not None:
             if self.adresse_ip != entree.client.adresse_ip:
                 return False
-        # Application du filtre sur le code de statut http si activé  
+        # Application du filtre sur le code de statut http si activé
         if self.code_statut_htpp is not None:
             if self.code_statut_htpp != entree.reponse.code_statut_http:
                 return False
-            
+
         return True
-    
+
     def get_dict_filtres(self) -> dict:
         """
         Retourne le filtre sous forme d'un dictionnaire.

--- a/app/analyse/filtre_log_apache.py
+++ b/app/analyse/filtre_log_apache.py
@@ -1,0 +1,89 @@
+"""
+Module pour les filtres lors d'une analyse d'un fichier log Apache.
+"""
+
+from typing import Optional
+from parse.entree_log_apache import EntreeLogApache
+
+
+class FiltreLogApache:
+    """
+    Représente le filtre à appliquer lors d'une analyse d'un fichier de log Apache.
+
+    Attributes:
+        adresse_ip (Optional[str]): L'adresse IP que doit avoir une entrée pour
+            pouvoir passer le filtre. Si sa valeur est ``None``, ce filtre ne sera
+            pas appliqué.
+        code_statut_http (Optional[int]): Le code de statut http que doit avoir une entrée
+            pour pouvoir passer le filtre. Si sa valeur est ``None``, ce filtre ne sera
+            pas appliqué.
+    """
+    
+    def __init__(self, filtre_adresse_ip: Optional[str], filtre_code_statut_http: Optional[int]):
+        """
+        Initalise le filtre à appliquer lors d'une analyse.
+
+        Args:
+            filtre_adresse_ip (Optional[str]): L'adresse IP que doit avoir une entrée pour
+                pouvoir passer le filtre. Si sa valeur est ``None``, cette vérification ne sera
+                pas appliqué.
+            filtre_code_statut_http (Optional[int]): Le code de statut http que doit 
+                avoir une entrée pour pouvoir passer le filtre. Si sa valeur est ``None``,
+                cette vérification ne sera pas appliqué.
+
+        Raises:
+            TypeError: Les paramètres ne sont pas du type attendu.
+        """
+        # Vérification des paramètres
+        if filtre_adresse_ip is not None and not isinstance(filtre_adresse_ip, str):
+            raise TypeError("L'adresse IP dans un filtre doit être une chaîne de caractère.")
+        if filtre_code_statut_http is not None and not isinstance(filtre_code_statut_http, int):
+            raise TypeError("Un code de statut http dans un filtre doit être un entier.")
+
+        # Ajout des filtres
+        self.adresse_ip = filtre_code_statut_http
+        self.code_statut_htpp = filtre_code_statut_http
+
+    def entree_passe_filtre(self, entree: EntreeLogApache) -> bool:
+        """
+        Indique si l'entrée passée en paramètre passe le filtre.
+
+        Args:
+            entree (EntreeLogApache): L'entrée à vérifier.
+
+        Returns:
+            bool: True si l'entrée passe le filtre, False sinon.
+
+        Raises:
+            TypeError: L'``entrée`` n'est pas de type :class:`EntreeLogApache`
+        """
+        # Vérification du paramètre
+        if not isinstance(entree, EntreeLogApache):
+            raise TypeError("L'entrée à vérifier pour le filtre doit être de type EntreeLogApache")
+
+        # Vérification que l'entrée passe le filtre
+        # Application du filtre sur l'adresse IP si activé
+        if self.adresse_ip is not None:
+            if self.adresse_ip != entree.client.adresse_ip:
+                return False
+        # Application du filtre sur le code de statut http si activé  
+        if self.code_statut_htpp is not None:
+            if self.code_statut_htpp != entree.reponse.code_statut_http:
+                return False
+            
+        return True
+    
+    def get_dict_filtres(self) -> dict:
+        """
+        Retourne le filtre sous forme d'un dictionnaire.
+        Les clés représentent le champs d'une entrée et leur valeur la valeur
+        que doit avoir ce champs. Si la valeur d'un filtre est ``None``, cela signifie que
+        cette vérification n'est pas activé.
+
+        Returns:
+            dict: Les filtres sous forme d'un dictionnaire.
+        """
+        return {
+            "adresse_ip": self.adresse_ip,
+            "code_statut_http": self.code_statut_htpp
+        }

--- a/app/analyse/filtre_log_apache.py
+++ b/app/analyse/filtre_log_apache.py
@@ -41,7 +41,7 @@ class FiltreLogApache:
             raise TypeError("Un code de statut http dans un filtre doit être un entier.")
 
         # Ajout des filtres
-        self.adresse_ip = filtre_code_statut_http
+        self.adresse_ip = filtre_adresse_ip
         self.code_statut_htpp = filtre_code_statut_http
 
     def entree_passe_filtre(self, entree: EntreeLogApache) -> bool:

--- a/app/analyse/filtre_log_apache.py
+++ b/app/analyse/filtre_log_apache.py
@@ -73,7 +73,7 @@ class FiltreLogApache:
 
         return True
 
-    def get_dict_filtres(self) -> dict:
+    def get_dict_filtre(self) -> dict:
         """
         Retourne le filtre sous forme d'un dictionnaire.
         Les clés représentent le champs d'une entrée et leur valeur la valeur

--- a/app/analyse/filtre_log_apache.py
+++ b/app/analyse/filtre_log_apache.py
@@ -37,12 +37,14 @@ class FiltreLogApache:
         # Vérification des paramètres
         if filtre_adresse_ip is not None and not isinstance(filtre_adresse_ip, str):
             raise TypeError("L'adresse IP dans un filtre doit être une chaîne de caractère.")
-        if filtre_code_statut_http is not None and not isinstance(filtre_code_statut_http, int):
+        if (filtre_code_statut_http is not None
+            and not isinstance(filtre_code_statut_http, int)
+            or isinstance(filtre_code_statut_http, bool)):
             raise TypeError("Un code de statut http dans un filtre doit être un entier.")
 
         # Ajout des filtres
         self.adresse_ip = filtre_adresse_ip
-        self.code_statut_htpp = filtre_code_statut_http
+        self.code_statut_http = filtre_code_statut_http
 
     def entree_passe_filtre(self, entree: EntreeLogApache) -> bool:
         """
@@ -67,8 +69,8 @@ class FiltreLogApache:
             if self.adresse_ip != entree.client.adresse_ip:
                 return False
         # Application du filtre sur le code de statut http si activé
-        if self.code_statut_htpp is not None:
-            if self.code_statut_htpp != entree.reponse.code_statut_http:
+        if self.code_statut_http is not None:
+            if self.code_statut_http != entree.reponse.code_statut_http:
                 return False
 
         return True
@@ -85,5 +87,5 @@ class FiltreLogApache:
         """
         return {
             "adresse_ip": self.adresse_ip,
-            "code_statut_http": self.code_statut_htpp
+            "code_statut_http": self.code_statut_http
         }

--- a/app/cli/parseur_arguments_cli.py
+++ b/app/cli/parseur_arguments_cli.py
@@ -44,6 +44,18 @@ class ParseurArgumentsCLI(ArgumentParser):
             help="Fichier JSON où sera écrit l'analyse. Par défaut, un fichier avec le "
             "nom 'analyse-log-apache.json' dans le repertoire courant sera crée.",
         )
+        self.add_argument(
+            "-i",
+            "--ip",
+            type=str,
+            help="L'adresse IP que doivent avoir les entrées à analyser."
+        )
+        self.add_argument(
+            "-c",
+            "--code-statut-http",
+            type=int,
+            help="Le code de statut http que doivent avoir les entrées à analyser."
+        )
 
     def parse_args(self,
                    args: Optional[list] = None,

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ Point d'entrée de l'application LogBuster !
 from cli.afficheur_cli import AfficheurCLI
 from cli.parseur_arguments_cli import ParseurArgumentsCLI, ArgumentCLIException
 from parse.parseur_log_apache import ParseurLogApache, ParsageLogApacheException
+from analyse.filtre_log_apache import FiltreLogApache
 from analyse.analyseur_log_apache import AnalyseurLogApache
 from export.exporteur import Exporteur, ExportationException
 
@@ -26,8 +27,10 @@ def main() -> None:
         # Analyse syntaxique du fichier log
         parseur_log = ParseurLogApache(arguments_cli.chemin_log)
         fichier_log = parseur_log.parse_fichier()
+        # Filtre à appliquer lors de l'analyse
+        filtre_log = FiltreLogApache(arguments_cli.ip, arguments_cli.code_statut_http)
         # Analyse statistique du fichier log
-        analyseur_log = AnalyseurLogApache(fichier_log)
+        analyseur_log = AnalyseurLogApache(fichier_log, filtre_log)
         analyse = analyseur_log.get_analyse_complete()
         # Exportation de l'analyse
         exporteur = Exporteur(arguments_cli.sortie)


### PR DESCRIPTION
- Ajout de la classe FiltreLogAPache qui représente un filtre à
  appliquer lors d'une analyse
- Ajout de l'argument du filtre sur l'adresse IP dans ParseurArgumentsCLI
- Ajout de l'argument du filtre sur le code de statut http dans ParseurArgumentsCLI
- Prise en compte uniquement des entrées qui passent le filtre dans
  l'analyseur de log Apache