### PR TITLE
Test: Ajout des tests unitaires pour FiltreLogApache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from cli.afficheur_cli import AfficheurCLI
 from cli.parseur_arguments_cli import ParseurArgumentsCLI
 from parse.parseur_log_apache import ParseurLogApache
+from analyse.filtre_log_apache import FiltreLogApache
 from analyse.analyseur_log_apache import AnalyseurLogApache
 from export.exporteur import Exporteur
 
@@ -148,21 +149,34 @@ def entree_log_apache(fichier_log_apache):
     """
     return fichier_log_apache.entrees[0]
 
+@pytest.fixture
+def filtre_log_apache():
+    """
+    Fixture pour initialiser un filtre de fichier de log Apache.
+    Par défaut, toutes les vérifications de ce filtre sont à ``None``.
+
+    Returns:
+        FiltreLogApache: Une instance de la classe :class:`FiltreLogApache`.
+    """
+    return FiltreLogApache(None, None)
+
 @pytest.fixture()
-def analyseur_log_apache(fichier_log_apache):
+def analyseur_log_apache(fichier_log_apache, filtre_log_apache):
     """
     Fixture pour initialiser un analyseur statistique de fichier de log Apache.
     Le fichier qu'analyse cet analyseur comprend par défaut les entrées parsées de la liste
-    ``lignes_valides``.
+    ``lignes_valides`` et toutes les vérifications de sont filtres sont à ``None``.
 
     Args:
         fichier_log_apache (FichierLogApache): Fixture pour l'instance 
             de la classe :class:`FichierLogApache`.
+        filtre_log_apache (FiltreLogApache): Fixture pour l'instance 
+            de la classe :class:`FiltreLogApache`.
 
     Returns:
         AnalyseurLogApache: Une instance de la classe :class:`AnalyseurLogApache`.
     """
-    return AnalyseurLogApache(fichier_log_apache)
+    return AnalyseurLogApache(fichier_log_apache, filtre_log_apache)
 
 @pytest.fixture
 def fichier_json(tmp_path):

--- a/tests/test_analyseur_log_apache.py
+++ b/tests/test_analyseur_log_apache.py
@@ -4,22 +4,25 @@ Modules des tests unitaires pour l'analyse statistique d'un fichier de log Apach
 
 import pytest
 from parse.fichier_log_apache import FichierLogApache
+from analyse.filtre_log_apache import FiltreLogApache
 from analyse.analyseur_log_apache import AnalyseurLogApache
 
 
 # Tests unitaires
 
-@pytest.mark.parametrize("fichier, nombre_par_top", [
-    (False, 3),
-    (FichierLogApache("test.log"), False)
+@pytest.mark.parametrize("fichier, filtre, nombre_par_top", [
+    (False, FiltreLogApache(None, None), 3),
+    (FichierLogApache("test.log"), False, 3),
+    (FichierLogApache("test.log"), FiltreLogApache(None, None), False)
 ])
-def test_analyseur_log_exception_type_invalide(fichier, nombre_par_top):
+def test_analyseur_log_exception_type_invalide(fichier, filtre, nombre_par_top):
     """
     Vérifie que la classe AnalyseurLogApache lève une :class:`TypeError` si les types des 
     paramètres du constructeur sont invalides.
 
     Scénarios testés:
         - Type incorrect pour le paramètre ``fichier``.
+        - Type incorrect pour le paramètre ``filtre``.
         - Type incorrect pour le paramètre ``nombre_par_top``.
 
     Asserts:
@@ -30,7 +33,7 @@ def test_analyseur_log_exception_type_invalide(fichier, nombre_par_top):
         nombre_par_top (any): Nombre maximum d'éléments dans le top classement.
     """
     with pytest.raises(TypeError):
-        analyseur = AnalyseurLogApache(fichier, nombre_par_top)
+        analyseur = AnalyseurLogApache(fichier, filtre, nombre_par_top)
 
 def test_analyseur_log_exception_valeur_nombre_par_top_invalide():
     """
@@ -44,7 +47,9 @@ def test_analyseur_log_exception_valeur_nombre_par_top_invalide():
         - Une exception :class:`ValueError` est levée.
     """
     with pytest.raises(ValueError):
-        analyseur = AnalyseurLogApache(FichierLogApache("test.log"), -4)
+        analyseur = AnalyseurLogApache(FichierLogApache("test.log"),
+                                       FiltreLogApache(None, None),
+                                       -4)
 
 @pytest.mark.parametrize("liste_elements, nom_element, mode_top_classement", [
     (0, "test", True),
@@ -189,7 +194,7 @@ def test_analyseur_top_urls_valide(analyseur_log_apache):
     assert top_urls[1]["total"] == 2
     assert top_urls[1]["taux"] == 40.0
 
-def test_analyseur_repartition_code_statut_htpp_valide(analyseur_log_apache):
+def test_analyseur_repartition_code_statut_http_valide(analyseur_log_apache):
     """
     Vérifie que ``get_total_par_code_statut_http`` retourne la répartition correcte des codes HTTP.
 
@@ -241,6 +246,45 @@ def test_analyseur_get_total_entrees_valide(analyseur_log_apache,
     fichier_log_apache.entrees = [entree_log_apache] * nombre_entrees
     assert analyseur_log_apache.get_total_entrees() == nombre_entrees
 
+@pytest.mark.parametrize("nombre_entrees_valides", [
+    (0), (3), (100)
+])
+def test_analyseur_get_entrees_passent_filtre_valide(mocker,
+                                                     analyseur_log_apache,
+                                                     entree_log_apache,
+                                                     nombre_entrees_valides):
+    """
+    Vérifie que ``_get_entrees_passent_filtre`` retourne la liste des entrées
+    qui passent le filtre.
+
+    Scénarios testés:
+        - Passage d'entrée à la méthode ``_get_entrees_passent_filtre``.
+
+    Asserts:
+        - Le nombre d'entrées retourné est égale au nombre de True retourné.
+        
+    Args:
+        mocker (any): Fixture pour simuler des attributs et retours de méthode.
+        analyseur_log_apache (AnalyseurLogApache): Fixture pour l'instance 
+            de la classe :class:`AnalyseurLogApache`.
+        entree_log_apache (EntreeLogApache): Fixture pour l'instance 
+            de la classe :class:`EntreeLogApache`.
+        nombre_entrees_valides (int): Le nombre d'entrées valides que retourne la méthode.
+    """
+    analyseur_log_apache.fichier = mocker.MagicMock()
+    analyseur_log_apache.fichier.entrees = [entree_log_apache] * (nombre_entrees_valides * 2)
+
+    retour_methode = [True] * nombre_entrees_valides
+    retour_methode += [False] * nombre_entrees_valides
+
+    analyseur_log_apache.filtre = mocker.MagicMock()
+    analyseur_log_apache.filtre.entree_passe_filtre.side_effect = retour_methode
+
+    entrees_filtre = analyseur_log_apache._get_entrees_passent_filtre()
+
+    assert entrees_filtre == [entree_log_apache] * nombre_entrees_valides
+    assert len(entrees_filtre) == nombre_entrees_valides
+
 def test_analyseur_get_analyse_complete_valide(analyseur_log_apache):
     """
     Vérifie que ``get_analyse_complete`` retourne un rapport de l'analyse correct
@@ -255,16 +299,13 @@ def test_analyseur_get_analyse_complete_valide(analyseur_log_apache):
     Args:
         analyseur_log_apache (AnalyseurLogApache): Fixture pour l'instance 
             de la classe :class:`AnalyseurLogApache`.
-        fichier_log_apache (FichierLogApache): Fixture pour l'instance 
-            de la classe :class:`FichierLogApache`.
-        entree_log_apache (EntreeLogApache): Fixture pour l'instance 
-            de la classe :class:`EntreeLogApache`.
-        nombre_entrees (int): Le nombre total d'entrées dans le fichier.
     """
     analyse = analyseur_log_apache.get_analyse_complete()
     assert analyse["chemin"] == analyseur_log_apache.fichier.chemin
+    assert analyse["total_entrees"] == analyseur_log_apache.get_total_entrees()
+    assert analyse["filtre"] == analyseur_log_apache.filtre.get_dict_filtre()
     statistiques = analyse["statistiques"]
-    assert statistiques["total_entrees"] == analyseur_log_apache.get_total_entrees()
+    assert statistiques["total_entrees_filtre"] == analyseur_log_apache.get_total_entrees_filtre()
     statistiques_requetes = statistiques["requetes"]
     assert statistiques_requetes["top_urls"] == analyseur_log_apache.get_top_urls()
     assert (statistiques_requetes["repartition_code_statut_http"] 

--- a/tests/test_filtre_log_apache.py
+++ b/tests/test_filtre_log_apache.py
@@ -1,0 +1,118 @@
+"""
+Module des tests unitaires pour le filtre de log Apache.
+"""
+
+import pytest
+from analyse.filtre_log_apache import FiltreLogApache
+
+
+# Tests unitaires
+
+@pytest.mark.parametrize("filtre_adresse_ip, filtre_code_statut_http", [
+    (False, 200),
+    ("127.0.0.1", False)
+])
+def test_filtre_log_type_invalide(filtre_adresse_ip, filtre_code_statut_http):
+    """
+    Vérifie que la classe renvoie une erreur lorsque un argument de type invalide
+    est passé dans le constructeur.
+
+    Scénarios testés:
+        - Type incorrect pour le paramètre ``filtre_adresse_ip``.
+        - Type incorrect pour le paramètre ``filtre_code_statut_http``.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        filtre_adresse_ip (any): La vérification sur l'adresse IP.
+        filtre_code_statut_http (any): La vérification sur le code de statut http.
+    """
+    with pytest.raises(TypeError):
+        filtre = FiltreLogApache(filtre_adresse_ip, filtre_code_statut_http)
+
+def test_filtre_log_entree_passe_filtre_type_invalide(filtre_log_apache):
+    """
+    Vérifie que la méthode ``entree_passe_filtre`` renvoie une erreur en cas
+    de type de paramètre invalide.
+
+    Scénarios testés:
+        - Type incorrect pour le paramètre ``entree``.
+
+    Asserts:
+        - Une exception :class:`TypeError` est levée.
+
+    Args:
+        filtre_log_apache (FiltreLogApache): Fixture pour l'instance 
+            de la classe :class:`FiltreLogApache`.
+    """
+    with pytest.raises(TypeError):
+        filtre_log_apache.entree_passe_filtre(False)
+
+@pytest.mark.parametrize("filtre_adresse_ip, adresse_ip_entree, retour_attendu", [
+    ("127.0.0.1", "127.0.0.1", True),
+    ("127.0.0.2", "127.0.0.1", False),
+    ("127.0.0.1", "127.0.0.2", False)
+])
+def test_filtre_log_entree_passe_filtre_adresse_ip_valide(filtre_log_apache,
+                                                      entree_log_apache,
+                                                      filtre_adresse_ip,
+                                                      adresse_ip_entree,
+                                                      retour_attendu):
+    """
+    Vérifie que la méthode ``entree_passe_filtre`` applique correctement la vérification
+    sur l'adresse IP.
+
+    Scénarios testés:
+        - L'adresse IP de l'entrée égale à celle du filtre.
+        - L'adresse IP de l'entrée différente de celle du filtre.
+
+    Asserts:
+        - La méthode ``entree_passe_filtre`` est égale à ``retour_attendu``.
+
+    Args:
+        filtre_log_apache (FiltreLogApache): Fixture pour l'instance 
+            de la classe :class:`FiltreLogApache`.
+        entree_log_apache (EntreeLogApache): Fixture pour l'instance 
+            de la classe :class:`EntreeLogApache`.
+        filtre_adresse_ip (str): La valeur du filtre de l'adresse IP.
+        adresse_ip_entree (str): L'adresse IP de l'entrée.
+        retour_attendu (bool): Le retour attendu par la méthode.
+    """
+    filtre_log_apache.adresse_ip = filtre_adresse_ip
+    entree_log_apache.client.adresse_ip = adresse_ip_entree
+    assert filtre_log_apache.entree_passe_filtre(entree_log_apache) == retour_attendu
+
+@pytest.mark.parametrize("filtre_code_statut_http, code_statut_http_entree, retour_attendu", [
+    (200, 200, True),
+    (404, 200, False),
+    (200, 404, False)
+])
+def test_filtre_log_entree_passe_filtre_code_statut_http_valide(filtre_log_apache,
+                                                      entree_log_apache,
+                                                      filtre_code_statut_http,
+                                                      code_statut_http_entree,
+                                                      retour_attendu):
+    """
+    Vérifie que la méthode ``entree_passe_filtre`` applique correctement la vérification
+    sur le code de statut http.
+
+    Scénarios testés:
+        - Le code de statut http de l'entrée égale à celle du filtre.
+        - Le code de statut http de l'entrée différente de celle du filtre.
+
+    Asserts:
+        - La méthode ``entree_passe_filtre`` est égale à ``retour_attendu``.
+
+    Args:
+        filtre_log_apache (FiltreLogApache): Fixture pour l'instance 
+            de la classe :class:`FiltreLogApache`.
+        entree_log_apache (EntreeLogApache): Fixture pour l'instance 
+            de la classe :class:`EntreeLogApache`.
+        filtre_code_statut_http (str): La valeur du filtre du code de statut http.
+        code_statut_http_entree (str): Le code de statut http de l'entrée.
+        retour_attendu (bool): Le retour attendu par la méthode.
+    """
+    filtre_log_apache.code_statut_http = filtre_code_statut_http
+    entree_log_apache.reponse.code_statut_http = code_statut_http_entree
+    assert filtre_log_apache.entree_passe_filtre(entree_log_apache) == retour_attendu

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,6 +52,8 @@ def test_main_succes(mocker):
         chemin_log="test.log"
     )
 
+    mocker.patch("main.FiltreLogApache")
+
     mock_parseur_log = mocker.patch("main.ParseurLogApache")
     mock_parseur_log.return_value.parse_fichier.return_value = mocker.MagicMock()
 

--- a/tests/test_parseur_arguments_cli.py
+++ b/tests/test_parseur_arguments_cli.py
@@ -196,3 +196,92 @@ def test_parseur_cli_verification_extention_chemin_sortie(parseur_arguments_cli)
     """
     with pytest.raises(ArgumentCLIException):
         parseur_arguments_cli.parse_args(args=["fichier.txt", "-s", "invalide.txt"])
+
+def test_parseur_cli_recuperation_chemin_sortie_defaut_valide(parseur_arguments_cli):
+    """
+    Vérifie que le chemin du fichier de sortie JSON par défaut est bien appliqué lorsque
+    aucun chemin de sortie n'est donné.
+
+    Scénarios testés:
+        - Demande de parsage avec aucun fichier de sortie indiqué.
+
+    Asserts:
+        - La bonne valeur par défaut pour le chemin de sortie à été appliquée.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurArgumentsCLI`.
+    """
+    argument = parseur_arguments_cli.parse_args(args=["fichier.txt"])
+    assert argument.sortie == "./analyse-log-apache.json"
+
+@pytest.mark.parametrize("adresse_ip", [
+    ("127.0.0.1"), ("192.168.0.0"), ("10.0.0.8")
+])
+def test_parseur_cli_recuperation_filtre_adresse_ip_valide(parseur_arguments_cli, adresse_ip):
+    """
+    Vérifie que le filtre sur l'adresse IP fourni depuis la ligne de commande est bien
+    récupéré par le parseur.
+
+    Scénarios testés:
+        - Ajout d'un filtre sur l'adresse IP dans les arguments de la CLI.
+
+    Asserts:
+        - La valeur de l'adresse IP est bien récupérée et conforme à l'entrée.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurArgumentsCLI`.
+        adresse_ip (str): Le filtre sur l'adresse IP.
+    """
+    arguments = parseur_arguments_cli.parse_args(args=["fichier.txt", "-i", adresse_ip])
+    assert arguments.ip == adresse_ip
+
+@pytest.mark.parametrize("code_statut_http", [
+    ("200"), ("302"), ("404")
+])
+def test_parseur_cli_recuperation_filtre_code_statut_http_valide(parseur_arguments_cli,
+                                                                 code_statut_http):
+    """
+    Vérifie que le filtre sur le code de statut http fourni depuis la ligne de commande est bien
+    récupéré par le parseur.
+
+    Scénarios testés:
+        - Ajout d'un filtre sur le code de statut http dans les arguments de la CLI.
+
+    Asserts:
+        - La valeur du code de statut http est bien récupérée et conforme à l'entrée.
+        - La valeur du code de statut http est bien convertie en entier.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurArgumentsCLI`.
+        code_statut_http (str): Le filtre sur le code de statut http.
+    """
+    arguments = parseur_arguments_cli.parse_args(args=["fichier.txt", "-c", code_statut_http])
+    assert arguments.code_statut_http == int(code_statut_http)
+
+@pytest.mark.parametrize("code_statut_http_invalide", [
+    ("test"), ("invalide")
+])
+def test_parseur_cli_exception_recuperation_filtre_code_statut_http_invalide(
+    parseur_arguments_cli,
+    code_statut_http_invalide):
+    """
+    Vérifie qu'une erreur se produit lorsque le filtre sur le code de statut http n'est pas
+    convertisable en un entier.
+
+    Scénarios testés:
+        - Ajout d'un filtre sur le code de statut http invalide dans les arguments de la CLI.
+
+    Asserts:
+        - Une exception :class:`ArgumentCLIException` est levée.
+
+    Args:
+        parseur_arguments_cli (ParseurArgumentsCLI): Fixture pour l'instance 
+            de la classe :class:`ParseurArgumentsCLI`.
+        code_statut_http_invalide (str): Le filtre invalide sur le code de statut http.
+    """
+    with pytest.raises(ArgumentCLIException):
+        arguments = parseur_arguments_cli.parse_args(
+            args=["fichier.txt", "-c", code_statut_http_invalide])


### PR DESCRIPTION
- Ajout des tests unitaires pour la classe FiltreLogApache
- Mise à jour des tests unitaires des classes ParseurArgumentsCLI et AnalyseurLogApache suite à l'ajout de la classe FiltreLogApache