### PR TITLE
Docs: Modification d'une erreur dans l'accueil de la documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,7 +62,7 @@ Dans LogBuster, l'**IP de l'utilisateur** et la **Date et heure de la requête**
 Format combiné (Combined Log Format)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Le format étendu permet d'ajouter plus de détails sur chaque requête.
+Le format combiné permet d'ajouter plus de détails sur chaque requête.
 Voici un exemple de ligne de log avec ce format :
 
 ``127.0.0.1 - - [10/Oct/2025:13:55:36 +0000] "GET /index.html HTTP/1.1" 200 2326 "http://referrer.com" "Mozilla/5.0"``


### PR DESCRIPTION
- Modification d'une erreur où le format de log Apache combiné était appelé 'format étendu'